### PR TITLE
Release v0.1.2: Python output alignment and performance comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,20 @@ PolarWarp is available in two implementations with identical functionality and o
 
 | Implementation | Speed | Best For |
 |----------------|-------|----------|
-| [**Rust**](rust/) | ~830K records/sec | Production use, large files, compiled binary |
-| [**Python**](python/) | ~1.4M records/sec* | Quick analysis, scripting, no compilation |
+| [**Rust**](rust/) | ~870K records/sec | Production use, large files, compiled binary |
+| [**Python**](python/) | ~850K records/sec | Quick analysis, scripting, no compilation |
 
-*Python speed measured on different hardware; both are significantly faster than MinIO's native tools.
+### Performance Comparison
+
+Benchmark results processing a 1.16M operation mixed workload log (zstd compressed):
+
+| Tool | Time | Speedup |
+|------|------|--------|
+| **PolarWarp (Rust)** | 1.34s | **8.4x faster** |
+| **PolarWarp (Python)** | 1.36s | **8.2x faster** |
+| MinIO `warp analyze` | 11.19s | baseline |
+
+Both PolarWarp implementations provide **8x faster** analysis than MinIO's native `warp analyze` tool, while also providing more detailed per-bucket latency breakdowns.
 
 ### Quick Start - Rust
 

--- a/python/README.md
+++ b/python/README.md
@@ -11,14 +11,18 @@ Python implementation of PolarWarp using [Polars](https://pola.rs/) for fast Dat
 
 ```bash
 cd python
-uv add polars pyarrow zstd
+uv venv --python 3.12
+source .venv/bin/activate
+uv pip install -e .
 ```
 
 ### Using pip
 
 ```bash
 cd python
-pip install -r requirements.txt
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
 ```
 
 ## Usage

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polars-warp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Add your description"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polarwarp-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Russ Fellows <russ.fellows@gmail.com>"]
 description = "A Rust implementation of polarWarp for processing oplog files"


### PR DESCRIPTION
- Python: Remove row index from output (matches Rust format)
- Python: Add processing time output
- Python: Add time module import
- Python: Update README with proper venv setup instructions
- Update version to 0.1.2 in Cargo.toml and pyproject.toml
- README: Add performance comparison table (8x faster than warp analyze)
- README: Update speed estimates based on actual benchmarks