### PR TITLE
V0.2.0: Summary file parsing, time-series charts, and lint cleanup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,32 @@ Both implementations (Rust `polarwarp-rs` and Python `polars-warp`) track the sa
 
 ---
 
+## [0.1.7] - 2026-05-15
+
+### New Features
+
+- **Summary file parsing** (Rust and Python) — PolarWarp now accepts aggregated summary files (e.g. `.summary.tsv.zst`) in addition to per-operation trace files. The file type is auto-detected from the header: if `bps` and `ops_per_sec` columns are present it is treated as a summary; if `duration_ns` is present it is treated as a trace.
+
+  Summary files contain one row per ~1-second time window per operation type (format: `op, start, end, bps, ops_per_sec, errors`), as produced by warp-replay and similar tools. An optional `# cmdline …` comment line before the header is silently skipped.
+
+  For summary files, PolarWarp reports throughput variability across segments, grouped by `op`:
+
+  | Column | Description |
+  |--------|-------------|
+  | `segments` | Number of 1-second windows observed |
+  | `mean/p50/p90/p99/min/max MBps` | Throughput distribution across segments |
+  | `stdev_MBps` | Sample standard deviation of throughput |
+  | `mean/p50/p99 ops/s` | Operation-rate distribution across segments |
+  | `total_errors` | Cumulative error count |
+
+  The `TOTAL` row is always printed last. When only one segment is present, `stdev_MBps` is shown as `N/A`.
+
+  With `--excel`, each summary file produces a dedicated `{name}-Summary` tab in the workbook.
+
+  Mixing trace and summary files in a single invocation is allowed (each is processed independently); a warning is emitted and consolidation is skipped for the summary files.
+
+---
+
 ## [0.1.6] - 2026-02-24
 
 ### Bug Fixes

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,38 @@ Both implementations (Rust `polarwarp-rs` and Python `polars-warp`) track the sa
 
 ---
 
+## [0.2.0] - 2026-05-15
+
+### New Features
+
+- **Time-series performance charts** (Rust and Python) — When processing summary files
+  (`.summary.tsv.zst`) with `--excel`, PolarWarp now generates a `{name}-Charts` Excel tab
+  alongside the existing `{name}-Summary` tab. The Charts tab contains two embedded line charts:
+
+  | Chart | X-axis | Y-axis | Series |
+  |-------|--------|--------|--------|
+  | Operations/sec over Time | Seconds from start | ops/sec | GET, PUT, META |
+  | Throughput (MiB/s) over Time | Seconds from start | MiB/s | GET, PUT |
+
+  The underlying time-series data (wide-format pivot table with one row per second) is written
+  above the charts for further analysis in Excel. META is excluded from the throughput chart
+  because metadata operations carry no meaningful byte payload.
+
+---
+
 ## [0.1.7] - 2026-05-15
 
 ### New Features
+
+- **Unit tests** — Both implementations now include comprehensive unit test suites:
+  - **Rust** (`rust/src/main.rs`): 28 tests covering `parse_skip_time`,
+    `format_with_commas`, `format_int_with_commas`, `format_duration_ns`,
+    `derive_short_name`, `derive_excel_path`, `make_tab_name`, `FileType` equality,
+    and `add_size_buckets`. Run with `cargo test`.
+  - **Python** (`python/tests/test_polarwarp.py`): 44 tests covering `format_with_commas`,
+    `_excel_derive_path`, short-name derivation, tab-name truncation, skip-pattern parsing,
+    timedelta formatting, file-type detection, summary stats aggregation, and size bucket logic.
+    Run with `uv run --group dev pytest tests/`.
 
 - **Summary file parsing** (Rust and Python) — PolarWarp now accepts aggregated summary files (e.g. `.summary.tsv.zst`) in addition to per-operation trace files. The file type is auto-detected from the header: if `bps` and `ops_per_sec` columns are present it is treated as a summary; if `duration_ns` is present it is treated as a trace.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](python/)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](rust/)
+[![Rust Tests](https://img.shields.io/badge/rust%20tests-28%20passing-brightgreen.svg)](rust/src/main.rs)
+[![Python Tests](https://img.shields.io/badge/python%20tests-44%20passing-brightgreen.svg)](python/tests/test_polarwarp.py)
 
 High-performance tool for analyzing storage I/O operation logs (oplog files from sai3-bench, MinIO Warp, etc.).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolarWarp
 
-[![Version](https://img.shields.io/badge/version-0.1.6-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
+[![Version](https://img.shields.io/badge/version-0.1.7-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](python/)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](rust/)
@@ -10,6 +10,7 @@ High-performance tool for analyzing storage I/O operation logs (oplog files from
 ## Features
 
 - **Multi-format support**: TSV and CSV files, with automatic zstd decompression and separator detection
+- **Dual file type support**: Per-operation trace files (`.trace.tsv.zst`) *and* aggregated summary files (`.summary.tsv.zst`) — file type is auto-detected from header columns
 - **Size-bucketed analysis**: 9 size buckets (zero, 1B-8KiB, ... >2GiB)
 - **Summary rows**: Aggregate statistics for META (LIST/HEAD/DELETE/STAT), GET, and PUT operations
 - **Per-client statistics**: Compare performance across multiple clients with `--per-client` option
@@ -195,13 +196,37 @@ Both implementations use identical bucket definitions (matching sai3-bench):
 
 ## Input File Format
 
-Expected columns (sai3-bench oplog format):
+PolarWarp auto-detects the file type from its header columns.
+
+### Trace files (per-operation oplog)
+
+Required columns (sai3-bench / warp oplog format):
 
 ```
 idx  thread  op  client_id  n_objects  bytes  endpoint  file  error  start  first_byte  end  duration_ns
 ```
 
 Also supports MinIO Warp CSV output format.
+
+### Summary files (aggregated time-series)
+
+PolarWarp can also parse the aggregated summary output produced by warp-replay and similar tools. These files use the columns:
+
+```
+op  start  end  bps  ops_per_sec  errors
+```
+
+Each row represents one ~1-second time window per operation type (plus a `TOTAL` row). Files may contain an optional `# cmdline …` comment before the header.
+
+For summary files, PolarWarp reports throughput variability statistics across segments:
+
+```
+      op   segs  mean_MBps   p50_MBps   p90_MBps   p99_MBps   min_MBps   max_MBps stdev_MBps mean_ops/s  p50_ops/s  p99_ops/s  total_errors
+     GET    120   2,048.00   2,032.15   2,350.40   2,478.20   1,800.00   2,520.00     142.33     512.00     508.04     619.55             0
+   TOTAL    120   2,048.00   2,032.15   2,350.40   2,478.20   1,800.00   2,520.00        N/A     512.00     508.04     619.55             0
+```
+
+With `--excel`, summary files produce a dedicated `{name}-Summary` tab in the workbook.
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolarWarp
 
-[![Version](https://img.shields.io/badge/version-0.1.7-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
+[![Version](https://img.shields.io/badge/version-0.2.0-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](python/)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](rust/)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ High-performance tool for analyzing storage I/O operation logs (oplog files from
 - **Summary rows**: Aggregate statistics for META (LIST/HEAD/DELETE/STAT), GET, and PUT operations
 - **Per-client statistics**: Compare performance across multiple clients with `--per-client` option
 - **Per-endpoint statistics**: Compare performance across storage endpoints with `--per-endpoint` option
-- **Excel export**: Export results to a formatted `.xlsx` workbook with `--excel` option
+- **Excel export**: Export results to a formatted `.xlsx` workbook with `--excel` option; summary files additionally produce time-series line charts
 - **Latency percentiles**: mean, median, p90, p95, p99, max (statistically valid)
 - **Throughput metrics**: ops/sec and MiB/sec per bucket
 - **Multi-file consolidation**: Combine results from multiple agents, with automatic overlap detection — sequential runs are flagged and skipped, partial overlaps are warned and trimmed to the intersection window
@@ -228,7 +228,9 @@ For summary files, PolarWarp reports throughput variability statistics across se
    TOTAL    120   2,048.00   2,032.15   2,350.40   2,478.20   1,800.00   2,520.00        N/A     512.00     508.04     619.55             0
 ```
 
-With `--excel`, summary files produce a dedicated `{name}-Summary` tab in the workbook.
+With `--excel`, summary files produce two dedicated tabs in the workbook:
+- **`{name}-Summary`** — aggregate throughput statistics (mean, p50, p90, p99, min, max, stdev) per op type
+- **`{name}-Charts`** — per-second time-series data with two embedded line charts: ops/sec over time (all op types) and throughput MiB/s over time (GET + PUT)
 
 ## Related Projects
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # PolarWarp - Python Implementation
 
-[![Version](https://img.shields.io/badge/version-0.1.7-brightgreen.svg)](../Changelog.md)
+[![Version](https://img.shields.io/badge/version-0.2.0-brightgreen.svg)](../Changelog.md)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
 [![Tests](https://img.shields.io/badge/tests-44%20passing-brightgreen.svg)](tests/test_polarwarp.py)
@@ -48,8 +48,11 @@ uv run ./polarwarp.py --skip=2m oplog.trace.tsv.zst
 # Compare performance across multiple clients
 uv run ./polarwarp.py --per-client multi_client_oplog.trace.tsv.zst
 
-# Export results to Excel (summary files get their own tab)
+# Export results to Excel
 uv run ./polarwarp.py --excel report.xlsx oplog.trace.tsv.zst
+
+# Summary files produce a Stats tab + a Charts tab (ops/sec and MiB/s over time)
+uv run ./polarwarp.py --excel run.summary.tsv.zst
 
 # Per-endpoint breakdown
 uv run ./polarwarp.py --per-endpoint oplog.trace.tsv.zst

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,6 @@
 # PolarWarp - Python Implementation
 
+[![Version](https://img.shields.io/badge/version-0.1.7-brightgreen.svg)](../Changelog.md)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
 
@@ -31,23 +32,26 @@ pip install -e .
 # Display help
 uv run ./polarwarp.py --help
 
-# Process a single file
-uv run ./polarwarp.py oplog.csv.zst
+# Process a single trace file
+uv run ./polarwarp.py oplog.trace.tsv.zst
 
 # Process multiple files (results are consolidated)
-uv run ./polarwarp.py agent-1.csv.zst agent-2.csv.zst
+uv run ./polarwarp.py agent-1.trace.tsv.zst agent-2.trace.tsv.zst
+
+# Process a summary file (type is auto-detected from header)
+uv run ./polarwarp.py run.summary.tsv.zst
 
 # Skip first 2 minutes of warmup
-uv run ./polarwarp.py --skip=2m oplog.csv.zst
+uv run ./polarwarp.py --skip=2m oplog.trace.tsv.zst
 
 # Compare performance across multiple clients
-uv run ./polarwarp.py --per-client multi_client_oplog.csv.zst
+uv run ./polarwarp.py --per-client multi_client_oplog.trace.tsv.zst
 
-# Export results to Excel
-uv run ./polarwarp.py --excel report.xlsx oplog.csv.zst
+# Export results to Excel (summary files get their own tab)
+uv run ./polarwarp.py --excel report.xlsx oplog.trace.tsv.zst
 
 # Per-endpoint breakdown
-uv run ./polarwarp.py --per-endpoint oplog.csv.zst
+uv run ./polarwarp.py --per-endpoint oplog.trace.tsv.zst
 ```
 
 ## Command Line Options

--- a/python/README.md
+++ b/python/README.md
@@ -3,6 +3,7 @@
 [![Version](https://img.shields.io/badge/version-0.1.7-brightgreen.svg)](../Changelog.md)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
+[![Tests](https://img.shields.io/badge/tests-44%20passing-brightgreen.svg)](tests/test_polarwarp.py)
 
 Python implementation of PolarWarp using [Polars](https://pola.rs/) for fast DataFrame operations.
 
@@ -90,3 +91,27 @@ Matching sai3-bench bucket definitions:
 | 6 | 32MiB-256MiB | 32 MiB to 256 MiB |
 | 7 | 256MiB-2GiB | 256 MiB to 2 GiB |
 | 8 | >2GiB | Greater than 2 GiB |
+
+## Testing
+
+The Python implementation has 44 unit tests covering `format_with_commas`, `_excel_derive_path`,
+short-name and tab-name helpers, skip-time pattern parsing, `timedelta` formatting,
+`detect_file_type`, `_compute_summary_stats_df`, and the size-bucket Polars expressions.
+
+Tests are located in `tests/test_polarwarp.py` and require [uv](https://github.com/astral-sh/uv).
+
+```bash
+cd python
+
+# Run all tests
+uv run --group dev pytest tests/test_polarwarp.py -v
+
+# Run a specific test class
+uv run --group dev pytest tests/test_polarwarp.py::TestSizeBuckets -v
+
+# Run quietly (summary only)
+uv run --group dev pytest tests/test_polarwarp.py -q
+```
+
+The `pytest` and `zstandard` packages are declared as dev-only dependencies in `pyproject.toml`
+under `[dependency-groups] dev` — they are not installed when users install polarwarp normally.

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -210,16 +210,17 @@ def compute_per_endpoint_stats(df, run_time_secs):
 # ─────────────────────────── Excel export ────────────────────────────────────
 
 def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
-                          cons_df=None, cons_secs=None):
+                          cons_df=None, cons_secs=None, summary_file_data=None):
     """Write all per-file and consolidated results to a multi-tab Excel workbook.
 
     Args:
-        excel_path:    Output .xlsx path.
-        saved_files:   List of dicts: {path, df (polars w/ buckets), run_secs}.
-        per_client:    Whether to write per-client detail tab.
-        per_endpoint:  Whether to write per-endpoint detail tab.
-        cons_df:       Consolidated polars DataFrame (multi-file only).
-        cons_secs:     Consolidated run time in seconds (multi-file only).
+        excel_path:        Output .xlsx path.
+        saved_files:       List of dicts: {path, df (polars w/ buckets), run_secs}.
+        per_client:        Whether to write per-client detail tab.
+        per_endpoint:      Whether to write per-endpoint detail tab.
+        cons_df:           Consolidated polars DataFrame (multi-file only).
+        cons_secs:         Consolidated run time in seconds (multi-file only).
+        summary_file_data: List of dicts: {path, df} for .summary.tsv.zst files.
     """
     try:
         import xlsxwriter
@@ -472,6 +473,27 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             if per_client or per_endpoint:
                 _write_detail_tab(wb.add_worksheet('Consol-Detail'), cons_df, cons_secs)
 
+        # Write one tab per summary file
+        if summary_file_data:
+            import pandas as pd  # already imported above but guard just in case
+            summary_cols = [
+                "op", "segments",
+                "mean_MBps", "p50_MBps", "p90_MBps", "p99_MBps",
+                "min_MBps", "max_MBps", "stdev_MBps",
+                "mean_ops/s", "p50_ops/s", "p99_ops/s",
+                "total_errors",
+            ]
+            for entry in summary_file_data:
+                sfp, sdf = entry['path'], entry['df']
+                short = _short(sfp)
+                tab_name = _tab(short, 'Summary')
+                ws = wb.add_worksheet(tab_name)
+                stats_pl = _compute_summary_stats_df(sdf)
+                stats_pd = stats_pl.to_pandas()
+                # Keep only columns that exist (guard against schema changes)
+                ordered = [c for c in summary_cols if c in stats_pd.columns]
+                _write_df(ws, stats_pd[ordered], startrow=0)
+
         wb.close()
         print(f"\nExcel file written: {excel_path}")
 
@@ -589,6 +611,101 @@ def print_error(message):
     print(f"Run '{script_name} --help' for usage information.", file=sys.stderr)
     sys.exit(1)
 
+
+def detect_file_type(file_path):
+    """Detect whether a file is a per-op trace or an aggregated summary.
+
+    Reads the first non-comment row via Polars (handles .zst transparently).
+    Returns 'trace' or 'summary'.
+    """
+    try:
+        probe = pl.read_csv(
+            file_path,
+            n_rows=1,
+            separator='\t',
+            comment_prefix='#',
+            ignore_errors=True,
+            glob=False,
+        )
+    except Exception as e:
+        print_error(f"Cannot read file '{file_path}' to detect type: {e}")
+    cols = probe.columns
+    if 'bps' in cols and 'ops_per_sec' in cols:
+        return 'summary'
+    elif 'duration_ns' in cols:
+        return 'trace'
+    else:
+        print_error(
+            f"File '{file_path}' has unrecognized header columns: {cols}\n"
+            f"Expected either trace columns (duration_ns, …) or "
+            f"summary columns (bps, ops_per_sec, …)"
+        )
+
+
+def _compute_summary_stats_df(df):
+    """Compute per-op throughput variability stats from a summary DataFrame.
+
+    Returns a Polars DataFrame with one row per op, sorted (TOTAL last).
+    """
+    stats = (
+        df.group_by("op")
+        .agg([
+            pl.col("bps").count().alias("segments"),
+            (pl.col("bps").mean()          / 1_048_576).alias("mean_MBps"),
+            (pl.col("bps").median()         / 1_048_576).alias("p50_MBps"),
+            (pl.col("bps").quantile(0.90)   / 1_048_576).alias("p90_MBps"),
+            (pl.col("bps").quantile(0.99)   / 1_048_576).alias("p99_MBps"),
+            (pl.col("bps").min()            / 1_048_576).alias("min_MBps"),
+            (pl.col("bps").max()            / 1_048_576).alias("max_MBps"),
+            (pl.col("bps").std(ddof=1)      / 1_048_576).alias("stdev_MBps"),
+            pl.col("ops_per_sec").mean().alias("mean_ops/s"),
+            pl.col("ops_per_sec").median().alias("p50_ops/s"),
+            pl.col("ops_per_sec").quantile(0.99).alias("p99_ops/s"),
+            pl.col("errors").cast(pl.Int64).sum().alias("total_errors"),
+        ])
+        .sort("op")
+    )
+    # Re-sort: non-TOTAL rows first, TOTAL row last
+    non_total = stats.filter(pl.col("op") != "TOTAL")
+    total_row = stats.filter(pl.col("op") == "TOTAL")
+    return pl.concat([non_total, total_row])
+
+
+def compute_and_display_summary_stats(df):
+    """Display per-op throughput variability stats from a summary DataFrame."""
+    stats = _compute_summary_stats_df(df)
+    if stats.is_empty():
+        print("  (no data)")
+        return
+
+    def _fv(v):
+        """Format a numeric value; return 'N/A' for None."""
+        return format_with_commas(v) if v is not None else "N/A"
+
+    print(
+        f"{'op':>8} {'segs':>6} "
+        f"{'mean_MBps':>10} {'p50_MBps':>10} {'p90_MBps':>10} {'p99_MBps':>10} "
+        f"{'min_MBps':>10} {'max_MBps':>10} {'stdev_MBps':>10} "
+        f"{'mean_ops/s':>10} {'p50_ops/s':>10} {'p99_ops/s':>10} "
+        f"{'total_errors':>13}"
+    )
+    for row in stats.iter_rows(named=True):
+        print(
+            f"{row['op']:>8} {row['segments']:>6} "
+            f"{_fv(row['mean_MBps']):>10} "
+            f"{_fv(row['p50_MBps']):>10} "
+            f"{_fv(row['p90_MBps']):>10} "
+            f"{_fv(row['p99_MBps']):>10} "
+            f"{_fv(row['min_MBps']):>10} "
+            f"{_fv(row['max_MBps']):>10} "
+            f"{_fv(row['stdev_MBps']):>10} "
+            f"{_fv(row['mean_ops/s']):>10} "
+            f"{_fv(row['p50_ops/s']):>10} "
+            f"{_fv(row['p99_ops/s']):>10} "
+            f"{format_with_commas(row['total_errors']):>13}"
+        )
+
+
 # Check command line args, give basic usage
 if len(sys.argv) < 2:
     print_usage()
@@ -672,6 +789,11 @@ if excel_path == "":
 # Per-file data saved for Excel export
 saved_file_dfs = []  # list of dict: {path, df, run_secs}
 
+# Summary-file data collected separately for Excel export
+summary_file_data = []   # list of dict: {path, df}
+any_summary_file = False
+any_trace_file = False
+
 # Multi-file consolidation overlap thresholds (Jaccard = overlap / union).
 # Below MIN  -> files are sequential runs, consolidation is skipped.
 # Above MAX  -> files are treated as fully concurrent, no warning emitted.
@@ -694,7 +816,40 @@ for file_path in file_paths:
     try:
         print(f"\nProcessing file: {file_path}")
         process_start = time.time()
-        
+
+        # Detect file type and route summary files to their own handler
+        file_type = detect_file_type(file_path)
+        if file_type == 'summary':
+            any_summary_file = True
+            print(f"Summary Statistics for: {file_path}")
+            summary_df = pl.read_csv(
+                file_path,
+                separator='\t',
+                comment_prefix='#',
+                ignore_errors=True,
+                glob=False,
+            )
+            required_summary = ["op", "start", "end", "bps", "ops_per_sec", "errors"]
+            missing_s = [c for c in required_summary if c not in summary_df.columns]
+            if missing_s:
+                print_error(f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}")
+            summary_df = summary_df.with_columns([
+                pl.col("bps").cast(pl.Float64),
+                pl.col("ops_per_sec").cast(pl.Float64),
+            ])
+            seg_count = summary_df.height
+            start_val = summary_df.select(pl.col("start").first()).item()
+            end_val   = summary_df.select(pl.col("end").last()).item()
+            print(f"Time range: {start_val} → {end_val}  ({seg_count} segments)")
+            compute_and_display_summary_stats(summary_df)
+            if excel_path is not None:
+                summary_file_data.append({'path': file_path, 'df': summary_df})
+            process_elapsed = time.time() - process_start
+            print(f"\nProcessed in {process_elapsed:.2f} seconds")
+            continue
+
+        any_trace_file = True
+
         # Try to read the file with error handling
         # glob=False prevents polars from treating brackets in filenames as glob patterns
         try:
@@ -914,10 +1069,30 @@ for file_path in file_paths:
 
 # Done processing each file
 
+# Warn if user mixed trace and summary files
+if any_trace_file and any_summary_file:
+    print(
+        "WARNING: Mixed trace and summary files provided.  "
+        "Consolidation is skipped for summary files; each is reported independently.",
+        file=sys.stderr,
+    )
+
+# If only summary files were provided, write Excel if needed and exit now
+if not any_trace_file:
+    if excel_path is not None:
+        write_polarwarp_excel(
+            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+            summary_file_data=summary_file_data,
+        )
+    sys.exit(0)
+
 # If there was only one file to parse, write Excel if requested, then exit
 if len(file_paths) == 1:
     if excel_path is not None:
-        write_polarwarp_excel(excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats)
+        write_polarwarp_excel(
+            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+            summary_file_data=summary_file_data,
+        )
     sys.exit(0)
 
 print(f"\nDone Processing Files... Consolidating Results")
@@ -944,7 +1119,10 @@ if jaccard_pct < OVERLAP_MIN_PCT:
           f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold).")
     print("  Skipping consolidation \u2013 per-file results above are still valid.")
     if excel_path is not None:
-        write_polarwarp_excel(excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats)
+        write_polarwarp_excel(
+            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+            summary_file_data=summary_file_data,
+        )
     sys.exit(0)
 
 if jaccard_pct < OVERLAP_MAX_PCT:
@@ -1045,4 +1223,5 @@ if excel_path is not None:
     write_polarwarp_excel(
         excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
         consolidated_df, consolidated_run_secs,
+        summary_file_data=summary_file_data,
     )

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -5,44 +5,45 @@
 #
 # Program Description:  This program is designed to process the Minio Warp tool output files.
 #
-#    Using the Polars package to efficiently process data, this program operates approximately 
-#    20x faster than the default warp processing tool.  Additionally, this version uses about 
-#    10X *less* memory than the warp program, perhaps less.  If memory usage is still an issue, 
-#    this program may be modified, by reducing the "bytes_bucket" dataFrame based on the 
-#    values in the column "bytes".  Each reduction in the decision tree, reduces memory usage 
-#    by about 10 - 15%.  Currently, there are 8 buckets.  Reducing this to 4 buckets, would 
-#    cut memory use about 50%. 
-# 
-#    If multiple files are given on the command line to process, it will provide statistics 
-#    for each file individually, and then attempt to combine the results, if the runtimes 
-#    overlap.  If there is no overlapping time, then no consolidated results can be derived.   
+#    Using the Polars package to efficiently process data, this program operates approximately
+#    20x faster than the default warp processing tool.  Additionally, this version uses about
+#    10X *less* memory than the warp program, perhaps less.  If memory usage is still an issue,
+#    this program may be modified, by reducing the "bytes_bucket" dataFrame based on the
+#    values in the column "bytes".  Each reduction in the decision tree, reduces memory usage
+#    by about 10 - 15%.  Currently, there are 8 buckets.  Reducing this to 4 buckets, would
+#    cut memory use about 50%.
 #
-# Python Environment:  HIGHLY recommend using a modern package manager such as "uv" or "pixi" 
-#    to manage packages.  If you insist, old relics such as conda may work, but I wouldn't 
+#    If multiple files are given on the command line to process, it will provide statistics
+#    for each file individually, and then attempt to combine the results, if the runtimes
+#    overlap.  If there is no overlapping time, then no consolidated results can be derived.
+#
+# Python Environment:  HIGHLY recommend using a modern package manager such as "uv" or "pixi"
+#    to manage packages.  If you insist, old relics such as conda may work, but I wouldn't
 #    count on it, pip is probably fine.
 #
 # Example: if using uv, the following should add the necessary libraries
 #  uv add polars pyarrow zstandard zstd openpyxl
 #
 ################################
-import polars as pl
-from datetime import datetime, timedelta
-import sys
-import re
-import time
 import os
+import re
+import sys
+import time
+from datetime import timedelta
+
+import polars as pl
 
 # Metadata operations that should be grouped together (matching Rust implementation)
 META_OPS = ["LIST", "HEAD", "DELETE", "STAT"]
+
 
 # Function to pretty up the output, by adding commas for readability, and using 4 digits for float
 def format_with_commas(value):
     if isinstance(value, (int, float)):
         if isinstance(value, float):
             return f"{value:,.2f}"
-            #return f"{value:,.4f}"
-        else:
-            return f"{value:,}"
+            # return f"{value:,.4f}"
+        return f"{value:,}"
     return value  # Return the value unchanged if it's not numeric
 
 
@@ -53,75 +54,108 @@ def compute_per_client_stats(df, run_time_secs):
     """
     # Get unique clients
     clients = df.select(pl.col("client_id").unique()).to_series().to_list()
-    
+
     if len(clients) <= 1:
         print("\nOnly one client detected, skipping per-client statistics.")
         return None
-    
-    print(f"\n{'='*80}")
+
+    print(f"\n{'=' * 80}")
     print(f"Per-Client Statistics ({len(clients)} clients detected)")
-    print(f"{'='*80}")
-    
+    print(f"{'=' * 80}")
+
     # Compute stats for each client
-    client_stats = df.group_by(["client_id"]).agg([
-        (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-        (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-        (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-        (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-        (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-        (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
-        (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-        (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-        ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-        pl.count("op").alias("count"),
-    ]).sort("client_id")
-    
+    client_stats = (
+        df.group_by(["client_id"])
+        .agg(
+            [
+                (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+                (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+                (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
+                (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+                (pl.count("op") / run_time_secs).alias("ops_/_sec"),
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
+                    "xput_MBps"
+                ),
+                pl.count("op").alias("count"),
+            ]
+        )
+        .sort("client_id")
+    )
+
     # Convert to pandas for pretty printing
     client_stats_pd = client_stats.to_pandas()
-    
+
     columns_to_format = [
-        "mean_lat_us", "med._lat_us", "90%_lat_us", "95%_lat_us", "99%_lat_us", 
-        "max_lat_us", "avg_obj_KB", "ops_/_sec", "xput_MBps", "count"
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "max_lat_us",
+        "avg_obj_KB",
+        "ops_/_sec",
+        "xput_MBps",
+        "count",
     ]
-    
+
     for column in columns_to_format:
         if column in client_stats_pd:
             client_stats_pd[column] = client_stats_pd[column].map(format_with_commas)
-    
+
     print(client_stats_pd.to_string(index=False))
-    
+
     # Also compute per-client stats for each operation type
-    print(f"\nPer-Client Statistics by Operation Type:")
-    print(f"{'-'*80}")
-    
+    print("\nPer-Client Statistics by Operation Type:")
+    print(f"{'-' * 80}")
+
     for op_type in ["META", "GET", "PUT"]:
         if op_type == "META":
             op_df = df.filter(pl.col("op").is_in(META_OPS))
         else:
             op_df = df.filter(pl.col("op") == op_type)
-        
+
         if op_df.height == 0:
             continue
-        
-        op_client_stats = op_df.group_by(["client_id"]).agg([
-            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-            (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-            ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-            pl.count("op").alias("count"),
-        ]).sort("client_id")
-        
+
+        op_client_stats = (
+            op_df.group_by(["client_id"])
+            .agg(
+                [
+                    (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                    (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                    (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                    (pl.count("op") / run_time_secs).alias("ops_/_sec"),
+                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
+                        "xput_MBps"
+                    ),
+                    pl.count("op").alias("count"),
+                ]
+            )
+            .sort("client_id")
+        )
+
         op_client_stats_pd = op_client_stats.to_pandas()
-        
-        for column in ["mean_lat_us", "med._lat_us", "99%_lat_us", "ops_/_sec", "xput_MBps", "count"]:
+
+        for column in [
+            "mean_lat_us",
+            "med._lat_us",
+            "99%_lat_us",
+            "ops_/_sec",
+            "xput_MBps",
+            "count",
+        ]:
             if column in op_client_stats_pd:
-                op_client_stats_pd[column] = op_client_stats_pd[column].map(format_with_commas)
-        
+                op_client_stats_pd[column] = op_client_stats_pd[column].map(
+                    format_with_commas
+                )
+
         print(f"\n{op_type} Operations:")
         print(op_client_stats_pd.to_string(index=False))
-    
-    print(f"\n{'='*80}\n")
+
+    print(f"\n{'=' * 80}\n")
     return client_stats
 
 
@@ -134,47 +168,64 @@ def compute_per_endpoint_stats(df, run_time_secs):
         print("\nendpoint column not found, skipping per-endpoint statistics.")
         return None
 
-    endpoints = df.select(
-        pl.col("endpoint").drop_nulls().unique()
-    ).to_series().to_list()
+    endpoints = (
+        df.select(pl.col("endpoint").drop_nulls().unique()).to_series().to_list()
+    )
 
     if len(endpoints) <= 1:
         print("\nOnly one endpoint detected, skipping per-endpoint statistics.")
         return None
 
-    print(f"\n{'='*80}")
+    print(f"\n{'=' * 80}")
     print(f"Per-Endpoint Statistics ({len(endpoints)} endpoints detected)")
-    print(f"{'='*80}")
+    print(f"{'=' * 80}")
 
-    endpoint_stats = df.group_by(["endpoint"]).agg([
-        (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-        (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-        (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-        (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-        (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-        (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
-        (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-        (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-        ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-        pl.count("op").alias("count"),
-    ]).filter(
-        pl.col("endpoint").is_not_null() & (pl.col("count") > 0)
-    ).sort("endpoint")
+    endpoint_stats = (
+        df.group_by(["endpoint"])
+        .agg(
+            [
+                (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+                (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+                (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
+                (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+                (pl.count("op") / run_time_secs).alias("ops_/_sec"),
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
+                    "xput_MBps"
+                ),
+                pl.count("op").alias("count"),
+            ]
+        )
+        .filter(pl.col("endpoint").is_not_null() & (pl.col("count") > 0))
+        .sort("endpoint")
+    )
 
     endpoint_stats_pd = endpoint_stats.to_pandas()
     columns_to_format = [
-        "mean_lat_us", "med._lat_us", "90%_lat_us", "95%_lat_us", "99%_lat_us",
-        "max_lat_us", "avg_obj_KB", "ops_/_sec", "xput_MBps", "count"
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "max_lat_us",
+        "avg_obj_KB",
+        "ops_/_sec",
+        "xput_MBps",
+        "count",
     ]
     for column in columns_to_format:
         if column in endpoint_stats_pd:
-            endpoint_stats_pd[column] = endpoint_stats_pd[column].map(format_with_commas)
+            endpoint_stats_pd[column] = endpoint_stats_pd[column].map(
+                format_with_commas
+            )
 
     print(endpoint_stats_pd.to_string(index=False))
 
     # Per-endpoint stats by op type
-    print(f"\nPer-Endpoint Statistics by Operation Type:")
-    print(f"{'-'*80}")
+    print("\nPer-Endpoint Statistics by Operation Type:")
+    print(f"{'-' * 80}")
 
     for op_type in ["META", "GET", "PUT"]:
         if op_type == "META":
@@ -185,33 +236,55 @@ def compute_per_endpoint_stats(df, run_time_secs):
         if op_df.height == 0:
             continue
 
-        op_ep_stats = op_df.group_by(["endpoint"]).agg([
-            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-            (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-            ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-            pl.count("op").alias("count"),
-        ]).filter(
-            pl.col("endpoint").is_not_null() & (pl.col("count") > 0)
-        ).sort("endpoint")
+        op_ep_stats = (
+            op_df.group_by(["endpoint"])
+            .agg(
+                [
+                    (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                    (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                    (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                    (pl.count("op") / run_time_secs).alias("ops_/_sec"),
+                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
+                        "xput_MBps"
+                    ),
+                    pl.count("op").alias("count"),
+                ]
+            )
+            .filter(pl.col("endpoint").is_not_null() & (pl.col("count") > 0))
+            .sort("endpoint")
+        )
 
         op_ep_stats_pd = op_ep_stats.to_pandas()
-        for column in ["mean_lat_us", "med._lat_us", "99%_lat_us", "ops_/_sec", "xput_MBps", "count"]:
+        for column in [
+            "mean_lat_us",
+            "med._lat_us",
+            "99%_lat_us",
+            "ops_/_sec",
+            "xput_MBps",
+            "count",
+        ]:
             if column in op_ep_stats_pd:
                 op_ep_stats_pd[column] = op_ep_stats_pd[column].map(format_with_commas)
 
         print(f"\n{op_type} Operations:")
         print(op_ep_stats_pd.to_string(index=False))
 
-    print(f"\n{'='*80}\n")
+    print(f"\n{'=' * 80}\n")
     return endpoint_stats
 
 
 # ─────────────────────────── Excel export ────────────────────────────────────
 
-def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
-                          cons_df=None, cons_secs=None, summary_file_data=None):
+
+def write_polarwarp_excel(
+    excel_path,
+    saved_files,
+    per_client,
+    per_endpoint,
+    cons_df=None,
+    cons_secs=None,
+    summary_file_data=None,
+):
     """Write all per-file and consolidated results to a multi-tab Excel workbook.
 
     Args:
@@ -226,8 +299,10 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
     try:
         import xlsxwriter
     except ImportError:
-        print("Warning: xlsxwriter not installed — skipping Excel export. Run: uv pip install xlsxwriter",
-              file=sys.stderr)
+        print(
+            "Warning: xlsxwriter not installed — skipping Excel export. Run: uv pip install xlsxwriter",
+            file=sys.stderr,
+        )
         return
 
     import pandas as pd
@@ -237,20 +312,26 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
     # ── helpers ──────────────────────────────────────────────────────────────
     def _short(fp):
         n = os.path.basename(fp)
-        n = n.removesuffix('.zst')
-        n = n.removesuffix('.csv') if n.endswith('.csv') else \
-            n.removesuffix('.tsv') if n.endswith('.tsv') else n
-        bi = n.find('[')
+        n = n.removesuffix(".zst")
+        n = (
+            n.removesuffix(".csv")
+            if n.endswith(".csv")
+            else n.removesuffix(".tsv")
+            if n.endswith(".tsv")
+            else n
+        )
+        bi = n.find("[")
         if bi >= 0:
             n = n[:bi]
-        return n.rstrip('-_.')[:20]
+        return n.rstrip("-_.")[:20]
 
     def _tab(base, suf):
         full = f"{base}-{suf}"
-        return full if len(full) <= 31 else f"{base[:31-len(suf)-1]}-{suf}"
+        return full if len(full) <= 31 else f"{base[: 31 - len(suf) - 1]}-{suf}"
 
     def _op_eff_times(df, run_secs):
         """Return dict op_name → effective run time (seconds) for throughput."""
+
         def _ot(fdf):
             if fdf.height == 0:
                 return run_secs
@@ -260,6 +341,7 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                 return run_secs
             dt = (mx - mn).total_seconds()
             return dt if dt > 0.001 else run_secs
+
         mt = _ot(df.filter(pl.col("op").is_in(META_OPS)))
         gt = _ot(df.filter(pl.col("op") == "GET"))
         pt = _ot(df.filter(pl.col("op") == "PUT"))
@@ -285,48 +367,54 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
         if "thread" in df.columns:
             agg.append(pl.col("thread").n_unique().alias("max_threads"))
         result = df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(agg)
-        result = result.with_columns(
-            pl.col("op").map_elements(
-                lambda op: op_map.get(op, run_secs), return_dtype=pl.Float64
-            ).alias("runtime_s")
-        ).with_columns([
-            (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
-            (pl.col("bytes_sum") / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
-        ]).drop(["bytes_sum"])
+        result = (
+            result.with_columns(
+                pl.col("op")
+                .map_elements(
+                    lambda op: op_map.get(op, run_secs), return_dtype=pl.Float64
+                )
+                .alias("runtime_s")
+            )
+            .with_columns(
+                [
+                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias(
+                        "ops_/_sec"
+                    ),
+                    (pl.col("bytes_sum") / (1024 * 1024) / pl.col("runtime_s")).alias(
+                        "xput_MBps"
+                    ),
+                ]
+            )
+            .drop(["bytes_sum"])
+        )
         result = result.filter(pl.col("count") > 0).sort(["bucket_#", "op"])
-        col_order = (["op", "bytes_bucket", "bucket_#"] +
-                     ["mean_lat_us", "med._lat_us", "90%_lat_us", "95%_lat_us",
-                      "99%_lat_us", "max_lat_us", "avg_obj_KB", "ops_/_sec",
-                      "xput_MBps", "count"] +
-                     (["max_threads"] if "max_threads" in result.columns else []) +
-                     ["runtime_s"])
+        col_order = (
+            ["op", "bytes_bucket", "bucket_#"]
+            + [
+                "mean_lat_us",
+                "med._lat_us",
+                "90%_lat_us",
+                "95%_lat_us",
+                "99%_lat_us",
+                "max_lat_us",
+                "avg_obj_KB",
+                "ops_/_sec",
+                "xput_MBps",
+                "count",
+            ]
+            + (["max_threads"] if "max_threads" in result.columns else [])
+            + ["runtime_s"]
+        )
         return result.select([c for c in col_order if c in result.columns]).to_pandas()
 
     def _client_pd(df, run_secs):
         """Per-client overall stats (no printing)."""
         if "client_id" not in df.columns:
             return None
-        cs = df.group_by(["client_id"]).agg([
-            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-            (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-            (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-            (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
-            (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-            (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-            ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
-            pl.count("op").alias("count"),
-        ]).sort("client_id")
-        return cs.to_pandas() if cs.height > 0 else None
-
-    def _endpoint_pd(df, run_secs):
-        """Per-endpoint overall stats (no printing)."""
-        if "endpoint" not in df.columns:
-            return None
-        es = (df.filter(pl.col("endpoint").is_not_null())
-                .group_by(["endpoint"])
-                .agg([
+        cs = (
+            df.group_by(["client_id"])
+            .agg(
+                [
                     (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
                     (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
                     (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
@@ -335,11 +423,44 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                     (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                     (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                     (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-                    ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
+                    (
+                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
+                        / run_secs
+                    ).alias("xput_MBps"),
                     pl.count("op").alias("count"),
-                ])
-                .filter(pl.col("count") > 0)
-                .sort("endpoint"))
+                ]
+            )
+            .sort("client_id")
+        )
+        return cs.to_pandas() if cs.height > 0 else None
+
+    def _endpoint_pd(df, run_secs):
+        """Per-endpoint overall stats (no printing)."""
+        if "endpoint" not in df.columns:
+            return None
+        es = (
+            df.filter(pl.col("endpoint").is_not_null())
+            .group_by(["endpoint"])
+            .agg(
+                [
+                    (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                    (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                    (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+                    (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+                    (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                    (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
+                    (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+                    (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
+                    (
+                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
+                        / run_secs
+                    ).alias("xput_MBps"),
+                    pl.count("op").alias("count"),
+                ]
+            )
+            .filter(pl.col("count") > 0)
+            .sort("endpoint")
+        )
         return es.to_pandas() if es.height > 0 else None
 
     def _endpoint_pd_for_op(df, run_secs, op_type):
@@ -352,26 +473,33 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             op_df = df.filter(pl.col("op") == op_type)
         if op_df.height == 0:
             return None
-        es = (op_df.filter(pl.col("endpoint").is_not_null())
-                   .group_by(["endpoint"])
-                   .agg([
-                       (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-                       (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-                       (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-                       (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-                       ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
-                       pl.count("op").alias("count"),
-                   ])
-                   .filter(pl.col("count") > 0)
-                   .sort("endpoint"))
+        es = (
+            op_df.filter(pl.col("endpoint").is_not_null())
+            .group_by(["endpoint"])
+            .agg(
+                [
+                    (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                    (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                    (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                    (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
+                    (
+                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
+                        / run_secs
+                    ).alias("xput_MBps"),
+                    pl.count("op").alias("count"),
+                ]
+            )
+            .filter(pl.col("count") > 0)
+            .sort("endpoint")
+        )
         return es.to_pandas() if es.height > 0 else None
 
     # ── build workbook ────────────────────────────────────────────────────────
     try:
-        wb = xlsxwriter.Workbook(excel_path, {'strings_to_urls': False})
-        bold_fmt   = wb.add_format({'bold': True, 'font_name': 'Aptos', 'font_size': 11})
-        header_fmt = wb.add_format({'bold': True, 'font_name': 'Aptos'})
-        data_fmt   = wb.add_format({'font_name': 'Aptos'})
+        wb = xlsxwriter.Workbook(excel_path, {"strings_to_urls": False})
+        bold_fmt = wb.add_format({"bold": True, "font_name": "Aptos", "font_size": 11})
+        header_fmt = wb.add_format({"bold": True, "font_name": "Aptos"})
+        data_fmt = wb.add_format({"font_name": "Aptos"})
 
         def _write_df(ws, df_pd, startrow):
             """Write a pandas DataFrame to ws starting at startrow (0-based). Returns next free row."""
@@ -381,7 +509,7 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             for _, row in df_pd.iterrows():
                 for ci, val in enumerate(row):
                     if isinstance(val, float) and val != val:  # NaN → blank
-                        ws.write(startrow, ci, '', data_fmt)
+                        ws.write(startrow, ci, "", data_fmt)
                     elif isinstance(val, str):
                         ws.write_string(startrow, ci, val.strip(), data_fmt)
                     else:
@@ -394,7 +522,7 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             for _, row in df_pd.iterrows():
                 for ci, val in enumerate(row):
                     if isinstance(val, float) and val != val:
-                        ws.write(startrow, ci, '', data_fmt)
+                        ws.write(startrow, ci, "", data_fmt)
                     elif isinstance(val, str):
                         ws.write_string(startrow, ci, val.strip(), data_fmt)
                     else:
@@ -457,23 +585,34 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             # Parse ISO-8601 start strings to UTC datetimes, then compute
             # seconds-from-first-interval as an integer offset.
             df_filt = df_filt.with_columns(
-                pl.col("start").str.to_datetime(
-                    strict=False, time_unit="us", time_zone="UTC"
-                ).alias("start_dt")
+                pl.col("start")
+                .str.to_datetime(strict=False, time_unit="us", time_zone="UTC")
+                .alias("start_dt")
             )
             min_start = df_filt.select(pl.col("start_dt").min()).item()
-            df_filt = df_filt.with_columns([
-                (
-                    (pl.col("start_dt") - min_start).dt.total_microseconds() / 1_000_000.0
-                ).round(0).cast(pl.Int64).alias("seconds"),
-                (pl.col("bps") / 1_048_576.0).alias("MBps"),
-            ])
+            df_filt = df_filt.with_columns(
+                [
+                    (
+                        (pl.col("start_dt") - min_start).dt.total_microseconds()
+                        / 1_000_000.0
+                    )
+                    .round(0)
+                    .cast(pl.Int64)
+                    .alias("seconds"),
+                    (pl.col("bps") / 1_048_576.0).alias("MBps"),
+                ]
+            )
 
-            ops_list = sorted(df_filt.select(pl.col("op").unique()).to_series().to_list())
+            ops_list = sorted(
+                df_filt.select(pl.col("op").unique()).to_series().to_list()
+            )
 
             # Pivot ops_per_sec and MBps so each op becomes a column.
             ops_pivot = df_filt.pivot(
-                on="op", index="seconds", values="ops_per_sec", aggregate_function="mean"
+                on="op",
+                index="seconds",
+                values="ops_per_sec",
+                aggregate_function="mean",
             )
             ops_pivot = ops_pivot.rename(
                 {op: f"{op}_ops" for op in ops_list if op in ops_pivot.columns}
@@ -486,7 +625,9 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                 {op: f"{op}_MBps" for op in ops_list if op in bw_pivot.columns}
             )
 
-            ts_df = ops_pivot.join(bw_pivot, on="seconds", how="full", coalesce=True).sort("seconds")
+            ts_df = ops_pivot.join(
+                bw_pivot, on="seconds", how="full", coalesce=True
+            ).sort("seconds")
             return ts_df.to_pandas(), ops_list
 
         def _write_summary_chart_tab(wb, sdf, chart_tab_name):
@@ -507,45 +648,49 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             _write_df(ws, ts_pd, startrow=0)
 
             cols = list(ts_pd.columns)  # ['seconds', 'GET_ops', …, 'GET_MBps', …]
-            sec_ci = cols.index('seconds')
+            sec_ci = cols.index("seconds")
 
             # ── Chart 1: ops/sec over time ──────────────────────────────────────
-            chart_ops = wb.add_chart({'type': 'line'})
+            chart_ops = wb.add_chart({"type": "line"})
             for op in ops_list:
                 col_name = f"{op}_ops"
                 if col_name in cols:
                     ci = cols.index(col_name)
-                    chart_ops.add_series({
-                        'name':       op,
-                        'categories': [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
-                        'values':     [chart_tab_name, 1, ci,     n_rows, ci],
-                    })
-            chart_ops.set_title({'name': 'Operations/sec over Time'})
-            chart_ops.set_x_axis({'name': 'Seconds'})
-            chart_ops.set_y_axis({'name': 'ops/sec'})
-            chart_ops.set_legend({'position': 'bottom'})
+                    chart_ops.add_series(
+                        {
+                            "name": op,
+                            "categories": [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
+                            "values": [chart_tab_name, 1, ci, n_rows, ci],
+                        }
+                    )
+            chart_ops.set_title({"name": "Operations/sec over Time"})
+            chart_ops.set_x_axis({"name": "Seconds"})
+            chart_ops.set_y_axis({"name": "ops/sec"})
+            chart_ops.set_legend({"position": "bottom"})
 
             # ── Chart 2: throughput (MiB/s) — GET and PUT only ─────────────────
-            chart_bw = wb.add_chart({'type': 'line'})
-            for op in (o for o in ops_list if o in ('GET', 'PUT')):
+            chart_bw = wb.add_chart({"type": "line"})
+            for op in (o for o in ops_list if o in ("GET", "PUT")):
                 col_name = f"{op}_MBps"
                 if col_name in cols:
                     ci = cols.index(col_name)
-                    chart_bw.add_series({
-                        'name':       op,
-                        'categories': [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
-                        'values':     [chart_tab_name, 1, ci,     n_rows, ci],
-                    })
-            chart_bw.set_title({'name': 'Throughput (MiB/s) over Time'})
-            chart_bw.set_x_axis({'name': 'Seconds'})
-            chart_bw.set_y_axis({'name': 'MiB/s'})
-            chart_bw.set_legend({'position': 'bottom'})
+                    chart_bw.add_series(
+                        {
+                            "name": op,
+                            "categories": [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
+                            "values": [chart_tab_name, 1, ci, n_rows, ci],
+                        }
+                    )
+            chart_bw.set_title({"name": "Throughput (MiB/s) over Time"})
+            chart_bw.set_x_axis({"name": "Seconds"})
+            chart_bw.set_y_axis({"name": "MiB/s"})
+            chart_bw.set_legend({"position": "bottom"})
 
             # Place both charts below the data, side by side
             chart_row = n_rows + 3
             if any(f"{op}_ops" in cols for op in ops_list):
                 ws.insert_chart(chart_row, 0, chart_ops)
-            if any(f"{op}_MBps" in cols for op in ('GET', 'PUT')):
+            if any(f"{op}_MBps" in cols for op in ("GET", "PUT")):
                 ws.insert_chart(chart_row, 8, chart_bw)
 
         # Pre-compute unique short names to avoid worksheet name collisions when
@@ -553,7 +698,7 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
         if single:
             unique_shorts = [None]
         else:
-            raw_shorts = [_short(e['path']) for e in saved_files]
+            raw_shorts = [_short(e["path"]) for e in saved_files]
             tally = {}
             for n in raw_shorts:
                 tally[n] = tally.get(n, 0) + 1
@@ -568,36 +713,43 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                     unique_shorts.append(n)
 
         for i, entry in enumerate(saved_files):
-            fp, df, run_secs = entry['path'], entry['df'], entry['run_secs']
+            _, df, run_secs = entry["path"], entry["df"], entry["run_secs"]
             short = unique_shorts[i]
-            results_tab = 'Results' if single else _tab(short, 'Results')
+            results_tab = "Results" if single else _tab(short, "Results")
             _write_results_tab(wb.add_worksheet(results_tab), df, run_secs)
 
             if per_client or per_endpoint:
-                detail_tab = 'Detail' if single else _tab(short, 'Detail')
+                detail_tab = "Detail" if single else _tab(short, "Detail")
                 _write_detail_tab(wb.add_worksheet(detail_tab), df, run_secs)
 
         if cons_df is not None and not cons_df.is_empty():
-            _write_results_tab(wb.add_worksheet('Consolidated'), cons_df, cons_secs)
+            _write_results_tab(wb.add_worksheet("Consolidated"), cons_df, cons_secs)
             if per_client or per_endpoint:
-                _write_detail_tab(wb.add_worksheet('Consol-Detail'), cons_df, cons_secs)
+                _write_detail_tab(wb.add_worksheet("Consol-Detail"), cons_df, cons_secs)
 
         # Write one tab per summary file
         if summary_file_data:
-            import pandas as pd  # already imported above but guard just in case
             summary_cols = [
-                "op", "segments",
-                "mean_MBps", "p50_MBps", "p90_MBps", "p99_MBps",
-                "min_MBps", "max_MBps", "stdev_MBps",
-                "mean_ops/s", "p50_ops/s", "p99_ops/s",
+                "op",
+                "segments",
+                "mean_MBps",
+                "p50_MBps",
+                "p90_MBps",
+                "p99_MBps",
+                "min_MBps",
+                "max_MBps",
+                "stdev_MBps",
+                "mean_ops/s",
+                "p50_ops/s",
+                "p99_ops/s",
                 "total_errors",
             ]
             for entry in summary_file_data:
-                sfp, sdf = entry['path'], entry['df']
+                sfp, sdf = entry["path"], entry["df"]
                 short = _short(sfp)
 
                 # Summary statistics tab (aggregate stats per op)
-                tab_name = _tab(short, 'Summary')
+                tab_name = _tab(short, "Summary")
                 ws = wb.add_worksheet(tab_name)
                 stats_pl = _compute_summary_stats_df(sdf)
                 stats_pd = stats_pl.to_pandas()
@@ -606,13 +758,15 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                 _write_df(ws, stats_pd[ordered], startrow=0)
 
                 # Charts tab (time-series line charts)
-                _write_summary_chart_tab(wb, sdf, _tab(short, 'Charts'))
+                _write_summary_chart_tab(wb, sdf, _tab(short, "Charts"))
 
         wb.close()
         print(f"\nExcel file written: {excel_path}")
 
     except Exception as e:
-        print(f"Warning: Failed to write Excel file '{excel_path}': {e}", file=sys.stderr)
+        print(
+            f"Warning: Failed to write Excel file '{excel_path}': {e}", file=sys.stderr
+        )
 
 
 def compute_summary_rows(df, run_time_secs):
@@ -642,7 +796,7 @@ def compute_summary_rows(df, run_time_secs):
 
         # Compute per-op time range (issue #14: correct for non-overlapping workloads)
         min_start = category_df.select(pl.col("start").min()).item()
-        max_end   = category_df.select(pl.col("end").max()).item()
+        max_end = category_df.select(pl.col("end").max()).item()
         if min_start is not None and max_end is not None:
             op_time = (max_end - min_start).total_seconds()
             op_time = op_time if op_time > 0.001 else run_time_secs
@@ -650,21 +804,29 @@ def compute_summary_rows(df, run_time_secs):
             op_time = run_time_secs
 
         # Concurrency: distinct thread IDs for this op category (issue #16)
-        n_threads = int(category_df.select(pl.col("thread").n_unique()).item()) if has_thread else 0
+        n_threads = (
+            int(category_df.select(pl.col("thread").n_unique()).item())
+            if has_thread
+            else 0
+        )
 
         # Compute statistically valid percentiles on ALL raw data for this category
-        stats = category_df.select([
-            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-            (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-            (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-            (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
-            (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-            (pl.count("op").cast(pl.Float64) / op_time).alias("ops_/_sec"),
-            ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / op_time).alias("xput_MBps"),
-            pl.count("op").alias("count"),
-        ])
+        stats = category_df.select(
+            [
+                (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+                (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+                (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+                (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+                (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+                (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
+                (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+                (pl.count("op").cast(pl.Float64) / op_time).alias("ops_/_sec"),
+                (
+                    (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / op_time
+                ).alias("xput_MBps"),
+                pl.count("op").alias("count"),
+            ]
+        )
 
         row = stats.row(0, named=True)
         row["op"] = category_name
@@ -680,23 +842,37 @@ def compute_summary_rows(df, run_time_secs):
 def print_summary_rows(summary_rows, columns_to_format):
     """Print summary rows with formatting."""
     import pandas as pd
-    
+
     if not summary_rows:
         return
-    
+
     print()  # Separator line
-    
+
     summary_df = pd.DataFrame(summary_rows)
     # Reorder columns to match main output
-    column_order = ["op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
-                    "90%_lat_us", "95%_lat_us", "99%_lat_us", "max_lat_us",
-                    "avg_obj_KB", "ops_/_sec", "xput_MBps", "count", "max_threads", "runtime_s"]
+    column_order = [
+        "op",
+        "bytes_bucket",
+        "bucket_#",
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "max_lat_us",
+        "avg_obj_KB",
+        "ops_/_sec",
+        "xput_MBps",
+        "count",
+        "max_threads",
+        "runtime_s",
+    ]
     summary_df = summary_df[[c for c in column_order if c in summary_df.columns]]
-    
+
     for column in columns_to_format:
         if column in summary_df:
             summary_df[column] = summary_df[column].map(format_with_commas)
-    
+
     # Print without index, matching main output style
     print(summary_df.to_string(index=False))
 
@@ -705,19 +881,29 @@ def print_summary_rows(summary_rows, columns_to_format):
 
 script_name = sys.argv[0]
 
+
 def print_usage():
     """Print usage information."""
     print(f"Usage: python {script_name} [OPTIONS] <file1> [file2 ...]")
-    print(f"\nOptions:")
-    print(f"  --skip=<time>  Skip specified time from start of each file")
-    print(f"                 Format: <number>s (seconds) or <number>m (minutes)")
-    print(f"                 Example: --skip=90s or --skip=5m")
-    print(f"  --per-client   Generate per-client statistics (in addition to overall stats)")
-    print(f"  --per-endpoint Generate per-endpoint statistics (in addition to overall stats)")
-    print(f"  --excel[=FILE] Export results to Excel file (default name derived from input file)")
-    print(f"  --help         Show this help message and exit")
-    print(f"\nArguments:")
-    print(f"  file1 file2... One or more oplog files to process (TSV/CSV, optionally .zst compressed)")
+    print("\nOptions:")
+    print("  --skip=<time>  Skip specified time from start of each file")
+    print("                 Format: <number>s (seconds) or <number>m (minutes)")
+    print("                 Example: --skip=90s or --skip=5m")
+    print(
+        "  --per-client   Generate per-client statistics (in addition to overall stats)"
+    )
+    print(
+        "  --per-endpoint Generate per-endpoint statistics (in addition to overall stats)"
+    )
+    print(
+        "  --excel[=FILE] Export results to Excel file (default name derived from input file)"
+    )
+    print("  --help         Show this help message and exit")
+    print("\nArguments:")
+    print(
+        "  file1 file2... One or more oplog files to process (TSV/CSV, optionally .zst compressed)"
+    )
+
 
 def print_error(message):
     """Print error message and exit."""
@@ -736,24 +922,24 @@ def detect_file_type(file_path):
         probe = pl.read_csv(
             file_path,
             n_rows=1,
-            separator='\t',
-            comment_prefix='#',
+            separator="\t",
+            comment_prefix="#",
             ignore_errors=True,
             glob=False,
         )
     except Exception as e:
         print_error(f"Cannot read file '{file_path}' to detect type: {e}")
     cols = probe.columns
-    if 'bps' in cols and 'ops_per_sec' in cols:
-        return 'summary'
-    elif 'duration_ns' in cols:
-        return 'trace'
-    else:
-        print_error(
-            f"File '{file_path}' has unrecognized header columns: {cols}\n"
-            f"Expected either trace columns (duration_ns, …) or "
-            f"summary columns (bps, ops_per_sec, …)"
-        )
+    if "bps" in cols and "ops_per_sec" in cols:
+        return "summary"
+    if "duration_ns" in cols:
+        return "trace"
+    print_error(
+        f"File '{file_path}' has unrecognized header columns: {cols}\n"
+        f"Expected either trace columns (duration_ns, …) or "
+        f"summary columns (bps, ops_per_sec, …)"
+    )
+    return None  # unreachable: print_error calls sys.exit()
 
 
 def _compute_summary_stats_df(df):
@@ -763,20 +949,22 @@ def _compute_summary_stats_df(df):
     """
     stats = (
         df.group_by("op")
-        .agg([
-            pl.col("bps").count().alias("segments"),
-            (pl.col("bps").mean()          / 1_048_576).alias("mean_MBps"),
-            (pl.col("bps").median()         / 1_048_576).alias("p50_MBps"),
-            (pl.col("bps").quantile(0.90)   / 1_048_576).alias("p90_MBps"),
-            (pl.col("bps").quantile(0.99)   / 1_048_576).alias("p99_MBps"),
-            (pl.col("bps").min()            / 1_048_576).alias("min_MBps"),
-            (pl.col("bps").max()            / 1_048_576).alias("max_MBps"),
-            (pl.col("bps").std(ddof=1)      / 1_048_576).alias("stdev_MBps"),
-            pl.col("ops_per_sec").mean().alias("mean_ops/s"),
-            pl.col("ops_per_sec").median().alias("p50_ops/s"),
-            pl.col("ops_per_sec").quantile(0.99).alias("p99_ops/s"),
-            pl.col("errors").cast(pl.Int64).sum().alias("total_errors"),
-        ])
+        .agg(
+            [
+                pl.col("bps").count().alias("segments"),
+                (pl.col("bps").mean() / 1_048_576).alias("mean_MBps"),
+                (pl.col("bps").median() / 1_048_576).alias("p50_MBps"),
+                (pl.col("bps").quantile(0.90) / 1_048_576).alias("p90_MBps"),
+                (pl.col("bps").quantile(0.99) / 1_048_576).alias("p99_MBps"),
+                (pl.col("bps").min() / 1_048_576).alias("min_MBps"),
+                (pl.col("bps").max() / 1_048_576).alias("max_MBps"),
+                (pl.col("bps").std(ddof=1) / 1_048_576).alias("stdev_MBps"),
+                pl.col("ops_per_sec").mean().alias("mean_ops/s"),
+                pl.col("ops_per_sec").median().alias("p50_ops/s"),
+                pl.col("ops_per_sec").quantile(0.99).alias("p99_ops/s"),
+                pl.col("errors").cast(pl.Int64).sum().alias("total_errors"),
+            ]
+        )
         .sort("op")
     )
     # Re-sort: non-TOTAL rows first, TOTAL row last
@@ -824,11 +1012,16 @@ def compute_and_display_summary_stats(df):
 def _excel_derive_path(paths):
     if len(paths) == 1:
         name = os.path.basename(paths[0])
-        name = name.removesuffix('.zst')
-        name = name.removesuffix('.csv') if name.endswith('.csv') else name.removesuffix('.tsv') if name.endswith('.tsv') else name
-        return os.path.join(os.path.dirname(paths[0]) or '.', name + '.xlsx')
-    return 'polarwarp-results.xlsx'
-
+        name = name.removesuffix(".zst")
+        name = (
+            name.removesuffix(".csv")
+            if name.endswith(".csv")
+            else name.removesuffix(".tsv")
+            if name.endswith(".tsv")
+            else name
+        )
+        return os.path.join(os.path.dirname(paths[0]) or ".", name + ".xlsx")
+    return "polarwarp-results.xlsx"
 
 
 if __name__ == "__main__":
@@ -846,7 +1039,7 @@ if __name__ == "__main__":
     skip_time = None
     per_client_stats = False
     per_endpoint_stats = False
-    excel_path = None   # None = no Excel; string = path to write
+    excel_path = None  # None = no Excel; string = path to write
     file_paths = []
     skip_pattern = re.compile(r"^--skip=(\d+)([sm])$")
     excel_pattern = re.compile(r"^--excel(?:=(.+))?$")
@@ -864,10 +1057,15 @@ if __name__ == "__main__":
             else:
                 excel_m = excel_pattern.match(arg)
                 if excel_m:
-                    excel_path = excel_m.group(1)  # may be None if --excel with no value
+                    excel_path = excel_m.group(
+                        1
+                    )  # may be None if --excel with no value
                     if excel_path is None:
                         excel_path = ""  # sentinel: derive name later
-                    print(f"Excel export enabled" + (f": {excel_path}" if excel_path else ""))
+                    print(
+                        "Excel export enabled"
+                        + (f": {excel_path}" if excel_path else "")
+                    )
                     continue
                 match = skip_pattern.match(arg)
                 if match:
@@ -884,7 +1082,9 @@ if __name__ == "__main__":
                     except ValueError as e:
                         print_error(f"Invalid skip value: {e}")
                 else:
-                    print_error(f"Unknown option: {arg}\nValid options: --skip=<time>, --per-client, --per-endpoint, --excel[=FILE], --help")
+                    print_error(
+                        f"Unknown option: {arg}\nValid options: --skip=<time>, --per-client, --per-endpoint, --excel[=FILE], --help"
+                    )
         else:
             # This is a file path
             file_paths.append(arg)
@@ -906,7 +1106,7 @@ if __name__ == "__main__":
     saved_file_dfs = []  # list of dict: {path, df, run_secs}
 
     # Summary-file data collected separately for Excel export
-    summary_file_data = []   # list of dict: {path, df}
+    summary_file_data = []  # list of dict: {path, df}
     any_summary_file = False
     any_trace_file = False
 
@@ -922,7 +1122,7 @@ if __name__ == "__main__":
 
     # Create empty dataFrame for consolidate results
     consolidated_df = pl.DataFrame()
-    consolidated_throughput_df = pl.DataFrame() 
+    consolidated_throughput_df = pl.DataFrame()
     consolidated_throughputs = []
 
     #
@@ -935,31 +1135,42 @@ if __name__ == "__main__":
 
             # Detect file type and route summary files to their own handler
             file_type = detect_file_type(file_path)
-            if file_type == 'summary':
+            if file_type == "summary":
                 any_summary_file = True
                 print(f"Summary Statistics for: {file_path}")
                 summary_df = pl.read_csv(
                     file_path,
-                    separator='\t',
-                    comment_prefix='#',
+                    separator="\t",
+                    comment_prefix="#",
                     ignore_errors=True,
                     glob=False,
                 )
-                required_summary = ["op", "start", "end", "bps", "ops_per_sec", "errors"]
+                required_summary = [
+                    "op",
+                    "start",
+                    "end",
+                    "bps",
+                    "ops_per_sec",
+                    "errors",
+                ]
                 missing_s = [c for c in required_summary if c not in summary_df.columns]
                 if missing_s:
-                    print_error(f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}")
-                summary_df = summary_df.with_columns([
-                    pl.col("bps").cast(pl.Float64),
-                    pl.col("ops_per_sec").cast(pl.Float64),
-                ])
+                    print_error(
+                        f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}"
+                    )
+                summary_df = summary_df.with_columns(
+                    [
+                        pl.col("bps").cast(pl.Float64),
+                        pl.col("ops_per_sec").cast(pl.Float64),
+                    ]
+                )
                 seg_count = summary_df.height
                 start_val = summary_df.select(pl.col("start").first()).item()
-                end_val   = summary_df.select(pl.col("end").last()).item()
+                end_val = summary_df.select(pl.col("end").last()).item()
                 print(f"Time range: {start_val} → {end_val}  ({seg_count} segments)")
                 compute_and_display_summary_stats(summary_df)
                 if excel_path is not None:
-                    summary_file_data.append({'path': file_path, 'df': summary_df})
+                    summary_file_data.append({"path": file_path, "df": summary_df})
                 process_elapsed = time.time() - process_start
                 print(f"\nProcessed in {process_elapsed:.2f} seconds")
                 continue
@@ -969,7 +1180,9 @@ if __name__ == "__main__":
             # Try to read the file with error handling
             # glob=False prevents polars from treating brackets in filenames as glob patterns
             try:
-                df = pl.read_csv(file_path, ignore_errors=True, separator='\t', glob=False)
+                df = pl.read_csv(
+                    file_path, ignore_errors=True, separator="\t", glob=False
+                )
             except Exception as e:
                 print_error(f"Failed to read file '{file_path}': {e}")
 
@@ -981,14 +1194,28 @@ if __name__ == "__main__":
             required_columns = ["start", "end", "op", "bytes", "duration_ns"]
             missing_columns = [col for col in required_columns if col not in df.columns]
             if missing_columns:
-                print_error(f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}")
+                print_error(
+                    f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}"
+                )
 
-            # Note: parsing the ISO 8601 time is a bit tricky.  If the value ends in a literal capital "Z", then it may cause problems.  
+            # Note: parsing the ISO 8601 time is a bit tricky.  If the value ends in a literal capital "Z", then it may cause problems.
             try:
-                df = df.with_columns([
-                    pl.col("start").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("start"),
-                    pl.col("end").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("end"),
-                ])
+                df = df.with_columns(
+                    [
+                        pl.col("start")
+                        .str.replace("Z$", "+00:00")
+                        .str.strptime(
+                            pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False
+                        )
+                        .alias("start"),
+                        pl.col("end")
+                        .str.replace("Z$", "+00:00")
+                        .str.strptime(
+                            pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False
+                        )
+                        .alias("end"),
+                    ]
+                )
             except Exception as e:
                 print_error(f"Failed to parse timestamps in file '{file_path}': {e}")
 
@@ -1010,7 +1237,9 @@ if __name__ == "__main__":
 
             # If this error is raised, likely a time parsing issue
             if start_time is None or end_time is None:
-                print_error(f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)")
+                print_error(
+                    f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)"
+                )
 
         except KeyboardInterrupt:
             print("\n\nInterrupted by user", file=sys.stderr)
@@ -1029,63 +1258,96 @@ if __name__ == "__main__":
             print(f"Skipping rows with 'start' <= {threshold_time}.")
             df = df.filter(pl.col("start") > threshold_time)
 
-        print(f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}")
+        print(
+            f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}"
+        )
 
-    # Define the bucket order (matching sai3-bench/polarwarp-rs)
-        bucket_order = ["zero", "1B-8KiB", "8KiB-64KiB", "64KiB-512KiB", "512KiB-4MiB", "4MiB-32MiB", "32MiB-256MiB", "256MiB-2GiB", ">2GiB"]
+        # Define the bucket order (matching sai3-bench/polarwarp-rs)
+        bucket_order = [
+            "zero",
+            "1B-8KiB",
+            "8KiB-64KiB",
+            "64KiB-512KiB",
+            "512KiB-4MiB",
+            "4MiB-32MiB",
+            "32MiB-256MiB",
+            "256MiB-2GiB",
+            ">2GiB",
+        ]
 
-    # Size bucket boundaries (matching sai3-bench)
-        BUCKET_8K = 8 * 1024           # 8 KiB
-        BUCKET_64K = 64 * 1024         # 64 KiB
-        BUCKET_512K = 512 * 1024       # 512 KiB
-        BUCKET_4M = 4 * 1024 * 1024    # 4 MiB
+        # Size bucket boundaries (matching sai3-bench)
+        BUCKET_8K = 8 * 1024  # 8 KiB
+        BUCKET_64K = 64 * 1024  # 64 KiB
+        BUCKET_512K = 512 * 1024  # 512 KiB
+        BUCKET_4M = 4 * 1024 * 1024  # 4 MiB
         BUCKET_32M = 32 * 1024 * 1024  # 32 MiB
         BUCKET_256M = 256 * 1024 * 1024  # 256 MiB
         BUCKET_2G = 2 * 1024 * 1024 * 1024  # 2 GiB
 
-    # Create buckets for byte ranges (matching sai3-bench bucket definitions)
-        df = df.with_columns([
-            pl.when(pl.col("bytes") == 0).then(pl.lit("zero"))
-            .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(pl.lit("1B-8KiB"))
-            .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(pl.lit("8KiB-64KiB"))
-            .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(pl.lit("64KiB-512KiB"))
-            .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(pl.lit("512KiB-4MiB"))
-            .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(pl.lit("4MiB-32MiB"))
-            .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(pl.lit("32MiB-256MiB"))
-            .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(pl.lit("256MiB-2GiB"))
-            .otherwise(pl.lit(">2GiB")).alias("bytes_bucket"),
-            pl.when(pl.col("bytes") == 0).then(0)
-            .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(1)
-            .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(2)
-            .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(3)
-            .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(4)
-            .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(5)
-            .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(6)
-            .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(7)
-            .otherwise(8).alias("bucket_#")
-        ])
+        # Create buckets for byte ranges (matching sai3-bench bucket definitions)
+        df = df.with_columns(
+            [
+                pl.when(pl.col("bytes") == 0)
+                .then(pl.lit("zero"))
+                .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K))
+                .then(pl.lit("1B-8KiB"))
+                .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K))
+                .then(pl.lit("8KiB-64KiB"))
+                .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K))
+                .then(pl.lit("64KiB-512KiB"))
+                .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M))
+                .then(pl.lit("512KiB-4MiB"))
+                .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M))
+                .then(pl.lit("4MiB-32MiB"))
+                .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M))
+                .then(pl.lit("32MiB-256MiB"))
+                .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G))
+                .then(pl.lit("256MiB-2GiB"))
+                .otherwise(pl.lit(">2GiB"))
+                .alias("bytes_bucket"),
+                pl.when(pl.col("bytes") == 0)
+                .then(0)
+                .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K))
+                .then(1)
+                .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K))
+                .then(2)
+                .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K))
+                .then(3)
+                .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M))
+                .then(4)
+                .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M))
+                .then(5)
+                .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M))
+                .then(6)
+                .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G))
+                .then(7)
+                .otherwise(8)
+                .alias("bucket_#"),
+            ]
+        )
 
-    # Pre-compute per-operation time ranges (issue #14: correct for non-overlapping workloads)
-        def _op_time(op_df):
+        # Pre-compute per-operation time ranges (issue #14: correct for non-overlapping workloads)
+        # Use default-argument capture to avoid cell-var-from-loop (run_time_secs is a loop var)
+        def _op_time(op_df, _t=run_time_secs):
             if op_df.height == 0:
-                return run_time_secs
+                return _t
             min_s = op_df.select(pl.col("start").min()).item()
             max_e = op_df.select(pl.col("end").max()).item()
             if min_s is None or max_e is None:
-                return run_time_secs
+                return _t
             dt = (max_e - min_s).total_seconds()
-            return dt if dt > 0.001 else run_time_secs
+            return dt if dt > 0.001 else _t
 
         _meta_time = _op_time(df.filter(pl.col("op").is_in(META_OPS)))
-        _get_time  = _op_time(df.filter(pl.col("op") == "GET"))
-        _put_time  = _op_time(df.filter(pl.col("op") == "PUT"))
+        _get_time = _op_time(df.filter(pl.col("op") == "GET"))
+        _put_time = _op_time(df.filter(pl.col("op") == "PUT"))
 
         # Build op -> run_time mapping
         _op_time_map = {op: _meta_time for op in META_OPS}
         _op_time_map["GET"] = _get_time
         _op_time_map["PUT"] = _put_time
 
-    # Now group the results by operation type and our bucket sizes
+        # Now group the results by operation type and our bucket sizes
         _agg_exprs = [
             (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
             (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
@@ -1103,21 +1365,42 @@ if __name__ == "__main__":
         result = df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(_agg_exprs)
 
         # Compute per-op throughput rates using the correct per-op time range (issue #14)
-        result = result.with_columns(
-            pl.col("op").map_elements(lambda op: _op_time_map.get(op, run_time_secs), return_dtype=pl.Float64).alias("runtime_s")
-        ).with_columns([
-            (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
-            (pl.col("bytes_sum").cast(pl.Float64) / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
-        ]).drop(["bytes_sum"])
+        result = (
+            result.with_columns(
+                pl.col("op")
+                .map_elements(
+                    lambda op, _m=_op_time_map, _t=run_time_secs: _m.get(op, _t),
+                    return_dtype=pl.Float64,
+                )
+                .alias("runtime_s")
+            )
+            .with_columns(
+                [
+                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias(
+                        "ops_/_sec"
+                    ),
+                    (
+                        pl.col("bytes_sum").cast(pl.Float64)
+                        / (1024 * 1024)
+                        / pl.col("runtime_s")
+                    ).alias("xput_MBps"),
+                ]
+            )
+            .drop(["bytes_sum"])
+        )
 
         # Ensure throughput is in Float64 format for consistency
         result = result.with_columns(pl.col("xput_MBps").cast(pl.Float64))
 
         # Calculate throughput metrics for the current file (used in multi-file consolidation)
-        throughput_metrics = df.group_by("op", "bytes_bucket").agg([
-            ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-            pl.count("op").alias("count"),
-        ])
+        throughput_metrics = df.group_by("op", "bytes_bucket").agg(
+            [
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
+                    "xput_MBps"
+                ),
+                pl.count("op").alias("count"),
+            ]
+        )
 
         # Ensure 'op' column is of type Utf8
         throughput_metrics = throughput_metrics.with_columns(pl.col("op").cast(pl.Utf8))
@@ -1128,14 +1411,30 @@ if __name__ == "__main__":
         final_result = final_result.filter(pl.col("count") > 0)
 
         # Reorder columns (runtime_s last)
-        _col_order = ["op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
-                      "90%_lat_us", "95%_lat_us", "99%_lat_us", "max_lat_us",
-                      "avg_obj_KB", "ops_/_sec", "xput_MBps", "count", "max_threads", "runtime_s"]
-        final_result = final_result.select([c for c in _col_order if c in final_result.columns])
+        _col_order = [
+            "op",
+            "bytes_bucket",
+            "bucket_#",
+            "mean_lat_us",
+            "med._lat_us",
+            "90%_lat_us",
+            "95%_lat_us",
+            "99%_lat_us",
+            "max_lat_us",
+            "avg_obj_KB",
+            "ops_/_sec",
+            "xput_MBps",
+            "count",
+            "max_threads",
+            "runtime_s",
+        ]
+        final_result = final_result.select(
+            [c for c in _col_order if c in final_result.columns]
+        )
 
         final_result_pd = final_result.to_pandas()
 
-    # List of columns to send to the pretty comma-fyer
+        # List of columns to send to the pretty comma-fyer
         columns_to_format = [
             "med._lat_us",
             "90%_lat_us",
@@ -1150,9 +1449,13 @@ if __name__ == "__main__":
         ]
         for column in columns_to_format:
             if column in final_result_pd:
-                final_result_pd[column] = final_result_pd[column].map(format_with_commas)
+                final_result_pd[column] = final_result_pd[column].map(
+                    format_with_commas
+                )
         if "runtime_s" in final_result_pd:
-            final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(lambda x: f"{x:.1f}")
+            final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(
+                lambda x: f"{x:.1f}"
+            )
 
         print(final_result_pd.to_string(index=False))
 
@@ -1174,14 +1477,15 @@ if __name__ == "__main__":
 
         # Save data for Excel export
         if excel_path is not None:
-            saved_file_dfs.append({'path': file_path, 'df': df, 'run_secs': run_time_secs})
+            saved_file_dfs.append(
+                {"path": file_path, "df": df, "run_secs": run_time_secs}
+            )
 
         consolidated_df = pl.concat([consolidated_df, df])
 
         # Append the metrics to consolidated_throughputs
-        #consolidated_throughput_df = pl.concat([consolidated_throughput_df, throughput_metrics])
+        # consolidated_throughput_df = pl.concat([consolidated_throughput_df, throughput_metrics])
         consolidated_throughputs.append(throughput_metrics)
-
 
     # Done processing each file
 
@@ -1197,7 +1501,10 @@ if __name__ == "__main__":
     if not any_trace_file:
         if excel_path is not None:
             write_polarwarp_excel(
-                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                excel_path,
+                saved_file_dfs,
+                per_client_stats,
+                per_endpoint_stats,
                 summary_file_data=summary_file_data,
             )
         sys.exit(0)
@@ -1206,12 +1513,15 @@ if __name__ == "__main__":
     if len(file_paths) == 1:
         if excel_path is not None:
             write_polarwarp_excel(
-                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                excel_path,
+                saved_file_dfs,
+                per_client_stats,
+                per_endpoint_stats,
                 summary_file_data=summary_file_data,
             )
         sys.exit(0)
 
-    print(f"\nDone Processing Files... Consolidating Results")
+    print("\nDone Processing Files... Consolidating Results")
 
     # Compute overlap (latest-start / earliest-end) and union (earliest-start / latest-end)
     # across all files. Jaccard = overlap / union is in [0, 100%].
@@ -1219,33 +1529,48 @@ if __name__ == "__main__":
         print(f"  File time range: {fp}  (duration: {fe - fs})")
 
     overlap_start = max(r[1] for r in file_ranges)
-    overlap_end   = min(r[2] for r in file_ranges)
-    union_start   = min(r[1] for r in file_ranges)
-    union_end     = max(r[2] for r in file_ranges)
+    overlap_end = min(r[2] for r in file_ranges)
+    union_start = min(r[1] for r in file_ranges)
+    union_end = max(r[2] for r in file_ranges)
 
     overlap_secs = max(0.0, (overlap_end - overlap_start).total_seconds())
-    union_secs   = (union_end - union_start).total_seconds()
-    jaccard_pct  = (overlap_secs / union_secs * 100.0) if union_secs > 0 and overlap_secs > 0 else 0.0
+    union_secs = (union_end - union_start).total_seconds()
+    jaccard_pct = (
+        (overlap_secs / union_secs * 100.0)
+        if union_secs > 0 and overlap_secs > 0
+        else 0.0
+    )
 
-    print(f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)")
+    print(
+        f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)"
+    )
     print(f"  Jaccard overlap: {jaccard_pct:.1f}%  (overlap / union)")
 
     if jaccard_pct < OVERLAP_MIN_PCT:
-        print(f"WARNING: Files appear to be sequential runs "
-              f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold).")
+        print(
+            f"WARNING: Files appear to be sequential runs "
+            f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold)."
+        )
         print("  Skipping consolidation \u2013 per-file results above are still valid.")
         if excel_path is not None:
             write_polarwarp_excel(
-                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                excel_path,
+                saved_file_dfs,
+                per_client_stats,
+                per_endpoint_stats,
                 summary_file_data=summary_file_data,
             )
         sys.exit(0)
 
     if jaccard_pct < OVERLAP_MAX_PCT:
-        print(f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  "
-              f"Filtering all files to overlap window before consolidating.")
+        print(
+            f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  "
+            f"Filtering all files to overlap window before consolidating."
+        )
     else:
-        print(f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window.")
+        print(
+            f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window."
+        )
 
     # Filter consolidated_df to only operations whose start falls within the overlap window.
     # This ensures counts and throughput are computed over the same time slice across all files.
@@ -1259,47 +1584,73 @@ if __name__ == "__main__":
 
     consolidated_run_time = overlap_end - overlap_start
     consolidated_run_secs = overlap_secs
-    print(f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}")
+    print(
+        f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}"
+    )
 
     # Adjust consolidated_stats to join on both "op" and "bytes_bucket"
     if consolidated_df.is_empty():
         print("No valid data to consolidate.")
         sys.exit(1)
 
-    consolidated_stats = consolidated_df.group_by(["op", "bytes_bucket", "bucket_#"]).agg([
-        (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-        (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-        (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-        (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-        (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-        (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-        pl.count("op").alias("tot_count"),
-    ])
-
+    consolidated_stats = consolidated_df.group_by(
+        ["op", "bytes_bucket", "bucket_#"]
+    ).agg(
+        [
+            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+            (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+            (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+            (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+            pl.count("op").alias("tot_count"),
+        ]
+    )
 
     # Combine all throughput metrics into a single DataFrame, grouped by "op" and "bytes_bucket"
     if consolidated_throughputs:
-        combined_throughputs = pl.concat(consolidated_throughputs).group_by(["op", "bytes_bucket"]).agg([
-            pl.col("xput_MBps").sum().alias("total_xput_MBps"),
-            (pl.col("count").sum() / consolidated_run_secs).alias("tot_ops_/_sec"),
-        ])
+        combined_throughputs = (
+            pl.concat(consolidated_throughputs)
+            .group_by(["op", "bytes_bucket"])
+            .agg(
+                [
+                    pl.col("xput_MBps").sum().alias("total_xput_MBps"),
+                    (pl.col("count").sum() / consolidated_run_secs).alias(
+                        "tot_ops_/_sec"
+                    ),
+                ]
+            )
+        )
     else:
-        combined_throughputs = pl.DataFrame({
-            "op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []
-        })
+        combined_throughputs = pl.DataFrame(
+            {"op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []}
+        )
 
     # Join consolidated throughput metrics on "op" and "bytes_bucket"
-    consolidated_stats = consolidated_stats.join(combined_throughputs, on=["op", "bytes_bucket"], how="left")
+    consolidated_stats = consolidated_stats.join(
+        combined_throughputs, on=["op", "bytes_bucket"], how="left"
+    )
     consolidated_stats = consolidated_stats.sort(["bucket_#", "op"])
 
     # Ensure all expected columns are present and in the desired order
     desired_column_order = [
-        "op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
-        "90%_lat_us", "95%_lat_us", "99%_lat_us", "avg_obj_KB",
-        "tot_ops_/_sec", "total_xput_MBps", "tot_count",
+        "op",
+        "bytes_bucket",
+        "bucket_#",
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "avg_obj_KB",
+        "tot_ops_/_sec",
+        "total_xput_MBps",
+        "tot_count",
     ]
 
-    consolidated_stats = consolidated_stats.select(desired_column_order).sort(["bucket_#", "op"])
+    consolidated_stats = consolidated_stats.select(desired_column_order).sort(
+        ["bucket_#", "op"]
+    )
 
     # Convert to pandas for final output formatting
     consolidated_stats_pd = consolidated_stats.to_pandas()
@@ -1317,7 +1668,9 @@ if __name__ == "__main__":
     ]
     for column in columns_to_format:
         if column in consolidated_stats_pd:
-            consolidated_stats_pd[column] = consolidated_stats_pd[column].map(format_with_commas)
+            consolidated_stats_pd[column] = consolidated_stats_pd[column].map(
+                format_with_commas
+            )
 
     print("Consolidated Results:")
     print(consolidated_stats_pd)
@@ -1337,7 +1690,11 @@ if __name__ == "__main__":
     # Write Excel for multi-file run
     if excel_path is not None:
         write_polarwarp_excel(
-            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
-            consolidated_df, consolidated_run_secs,
+            excel_path,
+            saved_file_dfs,
+            per_client_stats,
+            per_endpoint_stats,
+            consolidated_df,
+            consolidated_run_secs,
             summary_file_data=summary_file_data,
         )

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -30,6 +30,7 @@ from datetime import datetime, timedelta
 import sys
 import re
 import time
+import os
 
 # Metadata operations that should be grouped together (matching Rust implementation)
 META_OPS = ["LIST", "HEAD", "DELETE", "STAT"]
@@ -706,74 +707,6 @@ def compute_and_display_summary_stats(df):
         )
 
 
-# Check command line args, give basic usage
-if len(sys.argv) < 2:
-    print_usage()
-    sys.exit(1)
-
-# Process --help flag first
-if "--help" in sys.argv or "-h" in sys.argv:
-    print_usage()
-    sys.exit(0)
-
-# Process the --skip argument
-skip_time = None
-per_client_stats = False
-per_endpoint_stats = False
-excel_path = None   # None = no Excel; string = path to write
-file_paths = []
-skip_pattern = re.compile(r"^--skip=(\d+)([sm])$")
-excel_pattern = re.compile(r"^--excel(?:=(.+))?$")
-
-# Now process remaining arguments
-for arg in sys.argv[1:]:
-    if arg.startswith("--"):
-        # This is an option
-        if arg == "--per-client":
-            per_client_stats = True
-            print("Per-client statistics enabled")
-        elif arg == "--per-endpoint":
-            per_endpoint_stats = True
-            print("Per-endpoint statistics enabled")
-        else:
-            excel_m = excel_pattern.match(arg)
-            if excel_m:
-                excel_path = excel_m.group(1)  # may be None if --excel with no value
-                if excel_path is None:
-                    excel_path = ""  # sentinel: derive name later
-                print(f"Excel export enabled" + (f": {excel_path}" if excel_path else ""))
-                continue
-            match = skip_pattern.match(arg)
-            if match:
-                value, unit = match.groups()
-                try:
-                    value = int(value)
-                    if value <= 0:
-                        print_error(f"Skip value must be positive, got: {value}")
-                    if unit == "s":
-                        skip_time = timedelta(seconds=value)
-                    elif unit == "m":
-                        skip_time = timedelta(minutes=value)
-                    print(f"Using skip value of {skip_time}")
-                except ValueError as e:
-                    print_error(f"Invalid skip value: {e}")
-            else:
-                print_error(f"Unknown option: {arg}\nValid options: --skip=<time>, --per-client, --per-endpoint, --excel[=FILE], --help")
-    else:
-        # This is a file path
-        file_paths.append(arg)
-
-if not file_paths:
-    print_error("No input files provided")
-
-# Validate that files exist
-import os
-for file_path in file_paths:
-    if not os.path.exists(file_path):
-        print_error(f"File not found: {file_path}")
-    if not os.path.isfile(file_path):
-        print_error(f"Not a file: {file_path}")
-
 # Resolve Excel output path
 def _excel_derive_path(paths):
     if len(paths) == 1:
@@ -783,445 +716,515 @@ def _excel_derive_path(paths):
         return os.path.join(os.path.dirname(paths[0]) or '.', name + '.xlsx')
     return 'polarwarp-results.xlsx'
 
-if excel_path == "":
-    excel_path = _excel_derive_path(file_paths)
 
-# Per-file data saved for Excel export
-saved_file_dfs = []  # list of dict: {path, df, run_secs}
 
-# Summary-file data collected separately for Excel export
-summary_file_data = []   # list of dict: {path, df}
-any_summary_file = False
-any_trace_file = False
+if __name__ == "__main__":
+    # Check command line args, give basic usage
+    if len(sys.argv) < 2:
+        print_usage()
+        sys.exit(1)
 
-# Multi-file consolidation overlap thresholds (Jaccard = overlap / union).
-# Below MIN  -> files are sequential runs, consolidation is skipped.
-# Above MAX  -> files are treated as fully concurrent, no warning emitted.
-# Between MIN and MAX -> partial overlap: warn, but still consolidate the intersection.
-OVERLAP_MIN_PCT = 3.0
-OVERLAP_MAX_PCT = 97.0
+    # Process --help flag first
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print_usage()
+        sys.exit(0)
 
-# Per-file time ranges collected during the main loop [(path, file_start, file_end)]
-file_ranges = []
+    # Process the --skip argument
+    skip_time = None
+    per_client_stats = False
+    per_endpoint_stats = False
+    excel_path = None   # None = no Excel; string = path to write
+    file_paths = []
+    skip_pattern = re.compile(r"^--skip=(\d+)([sm])$")
+    excel_pattern = re.compile(r"^--excel(?:=(.+))?$")
 
-# Create empty dataFrame for consolidate results
-consolidated_df = pl.DataFrame()
-consolidated_throughput_df = pl.DataFrame() 
-consolidated_throughputs = []
+    # Now process remaining arguments
+    for arg in sys.argv[1:]:
+        if arg.startswith("--"):
+            # This is an option
+            if arg == "--per-client":
+                per_client_stats = True
+                print("Per-client statistics enabled")
+            elif arg == "--per-endpoint":
+                per_endpoint_stats = True
+                print("Per-endpoint statistics enabled")
+            else:
+                excel_m = excel_pattern.match(arg)
+                if excel_m:
+                    excel_path = excel_m.group(1)  # may be None if --excel with no value
+                    if excel_path is None:
+                        excel_path = ""  # sentinel: derive name later
+                    print(f"Excel export enabled" + (f": {excel_path}" if excel_path else ""))
+                    continue
+                match = skip_pattern.match(arg)
+                if match:
+                    value, unit = match.groups()
+                    try:
+                        value = int(value)
+                        if value <= 0:
+                            print_error(f"Skip value must be positive, got: {value}")
+                        if unit == "s":
+                            skip_time = timedelta(seconds=value)
+                        elif unit == "m":
+                            skip_time = timedelta(minutes=value)
+                        print(f"Using skip value of {skip_time}")
+                    except ValueError as e:
+                        print_error(f"Invalid skip value: {e}")
+                else:
+                    print_error(f"Unknown option: {arg}\nValid options: --skip=<time>, --per-client, --per-endpoint, --excel[=FILE], --help")
+        else:
+            # This is a file path
+            file_paths.append(arg)
 
-#
-# Primary loop, process each file
-#
-for file_path in file_paths:
-    try:
-        print(f"\nProcessing file: {file_path}")
-        process_start = time.time()
+    if not file_paths:
+        print_error("No input files provided")
 
-        # Detect file type and route summary files to their own handler
-        file_type = detect_file_type(file_path)
-        if file_type == 'summary':
-            any_summary_file = True
-            print(f"Summary Statistics for: {file_path}")
-            summary_df = pl.read_csv(
-                file_path,
-                separator='\t',
-                comment_prefix='#',
-                ignore_errors=True,
-                glob=False,
+    # Validate that files exist
+    for file_path in file_paths:
+        if not os.path.exists(file_path):
+            print_error(f"File not found: {file_path}")
+        if not os.path.isfile(file_path):
+            print_error(f"Not a file: {file_path}")
+
+    if excel_path == "":
+        excel_path = _excel_derive_path(file_paths)
+
+    # Per-file data saved for Excel export
+    saved_file_dfs = []  # list of dict: {path, df, run_secs}
+
+    # Summary-file data collected separately for Excel export
+    summary_file_data = []   # list of dict: {path, df}
+    any_summary_file = False
+    any_trace_file = False
+
+    # Multi-file consolidation overlap thresholds (Jaccard = overlap / union).
+    # Below MIN  -> files are sequential runs, consolidation is skipped.
+    # Above MAX  -> files are treated as fully concurrent, no warning emitted.
+    # Between MIN and MAX -> partial overlap: warn, but still consolidate the intersection.
+    OVERLAP_MIN_PCT = 3.0
+    OVERLAP_MAX_PCT = 97.0
+
+    # Per-file time ranges collected during the main loop [(path, file_start, file_end)]
+    file_ranges = []
+
+    # Create empty dataFrame for consolidate results
+    consolidated_df = pl.DataFrame()
+    consolidated_throughput_df = pl.DataFrame() 
+    consolidated_throughputs = []
+
+    #
+    # Primary loop, process each file
+    #
+    for file_path in file_paths:
+        try:
+            print(f"\nProcessing file: {file_path}")
+            process_start = time.time()
+
+            # Detect file type and route summary files to their own handler
+            file_type = detect_file_type(file_path)
+            if file_type == 'summary':
+                any_summary_file = True
+                print(f"Summary Statistics for: {file_path}")
+                summary_df = pl.read_csv(
+                    file_path,
+                    separator='\t',
+                    comment_prefix='#',
+                    ignore_errors=True,
+                    glob=False,
+                )
+                required_summary = ["op", "start", "end", "bps", "ops_per_sec", "errors"]
+                missing_s = [c for c in required_summary if c not in summary_df.columns]
+                if missing_s:
+                    print_error(f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}")
+                summary_df = summary_df.with_columns([
+                    pl.col("bps").cast(pl.Float64),
+                    pl.col("ops_per_sec").cast(pl.Float64),
+                ])
+                seg_count = summary_df.height
+                start_val = summary_df.select(pl.col("start").first()).item()
+                end_val   = summary_df.select(pl.col("end").last()).item()
+                print(f"Time range: {start_val} → {end_val}  ({seg_count} segments)")
+                compute_and_display_summary_stats(summary_df)
+                if excel_path is not None:
+                    summary_file_data.append({'path': file_path, 'df': summary_df})
+                process_elapsed = time.time() - process_start
+                print(f"\nProcessed in {process_elapsed:.2f} seconds")
+                continue
+
+            any_trace_file = True
+
+            # Try to read the file with error handling
+            # glob=False prevents polars from treating brackets in filenames as glob patterns
+            try:
+                df = pl.read_csv(file_path, ignore_errors=True, separator='\t', glob=False)
+            except Exception as e:
+                print_error(f"Failed to read file '{file_path}': {e}")
+
+            # Check if dataframe is empty
+            if df.is_empty():
+                print_error(f"File '{file_path}' contains no data")
+
+            # Check for required columns
+            required_columns = ["start", "end", "op", "bytes", "duration_ns"]
+            missing_columns = [col for col in required_columns if col not in df.columns]
+            if missing_columns:
+                print_error(f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}")
+
+            # Note: parsing the ISO 8601 time is a bit tricky.  If the value ends in a literal capital "Z", then it may cause problems.  
+            try:
+                df = df.with_columns([
+                    pl.col("start").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("start"),
+                    pl.col("end").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("end"),
+                ])
+            except Exception as e:
+                print_error(f"Failed to parse timestamps in file '{file_path}': {e}")
+
+            start_time = None
+            start_values_checked = []
+            for value in df.select(pl.col("start").drop_nulls()).to_series():
+                start_values_checked.append(value)
+                if value is not None:
+                    start_time = value
+                    break
+
+            end_time = None
+            end_values_checked = []
+            for value in reversed(df.select(pl.col("end").drop_nulls()).to_series()):
+                end_values_checked.append(value)
+                if value is not None:
+                    end_time = value
+                    break
+
+            # If this error is raised, likely a time parsing issue
+            if start_time is None or end_time is None:
+                print_error(f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)")
+
+        except KeyboardInterrupt:
+            print("\n\nInterrupted by user", file=sys.stderr)
+            sys.exit(130)
+        except Exception as e:
+            print_error(f"Unexpected error processing file '{file_path}': {e}")
+
+        # Per-file effective start (accounting for skip) and duration
+        file_start = (start_time + skip_time) if skip_time is not None else start_time
+        run_time = end_time - file_start
+        run_time_secs = run_time.total_seconds()
+        file_ranges.append((file_path, file_start, end_time))
+
+        if skip_time is not None:
+            threshold_time = start_time + skip_time
+            print(f"Skipping rows with 'start' <= {threshold_time}.")
+            df = df.filter(pl.col("start") > threshold_time)
+
+        print(f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}")
+
+    # Define the bucket order (matching sai3-bench/polarwarp-rs)
+        bucket_order = ["zero", "1B-8KiB", "8KiB-64KiB", "64KiB-512KiB", "512KiB-4MiB", "4MiB-32MiB", "32MiB-256MiB", "256MiB-2GiB", ">2GiB"]
+
+    # Size bucket boundaries (matching sai3-bench)
+        BUCKET_8K = 8 * 1024           # 8 KiB
+        BUCKET_64K = 64 * 1024         # 64 KiB
+        BUCKET_512K = 512 * 1024       # 512 KiB
+        BUCKET_4M = 4 * 1024 * 1024    # 4 MiB
+        BUCKET_32M = 32 * 1024 * 1024  # 32 MiB
+        BUCKET_256M = 256 * 1024 * 1024  # 256 MiB
+        BUCKET_2G = 2 * 1024 * 1024 * 1024  # 2 GiB
+
+    # Create buckets for byte ranges (matching sai3-bench bucket definitions)
+        df = df.with_columns([
+            pl.when(pl.col("bytes") == 0).then(pl.lit("zero"))
+            .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(pl.lit("1B-8KiB"))
+            .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(pl.lit("8KiB-64KiB"))
+            .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(pl.lit("64KiB-512KiB"))
+            .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(pl.lit("512KiB-4MiB"))
+            .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(pl.lit("4MiB-32MiB"))
+            .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(pl.lit("32MiB-256MiB"))
+            .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(pl.lit("256MiB-2GiB"))
+            .otherwise(pl.lit(">2GiB")).alias("bytes_bucket"),
+            pl.when(pl.col("bytes") == 0).then(0)
+            .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(1)
+            .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(2)
+            .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(3)
+            .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(4)
+            .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(5)
+            .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(6)
+            .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(7)
+            .otherwise(8).alias("bucket_#")
+        ])
+
+    # Pre-compute per-operation time ranges (issue #14: correct for non-overlapping workloads)
+        def _op_time(op_df):
+            if op_df.height == 0:
+                return run_time_secs
+            min_s = op_df.select(pl.col("start").min()).item()
+            max_e = op_df.select(pl.col("end").max()).item()
+            if min_s is None or max_e is None:
+                return run_time_secs
+            dt = (max_e - min_s).total_seconds()
+            return dt if dt > 0.001 else run_time_secs
+
+        _meta_time = _op_time(df.filter(pl.col("op").is_in(META_OPS)))
+        _get_time  = _op_time(df.filter(pl.col("op") == "GET"))
+        _put_time  = _op_time(df.filter(pl.col("op") == "PUT"))
+
+        # Build op -> run_time mapping
+        _op_time_map = {op: _meta_time for op in META_OPS}
+        _op_time_map["GET"] = _get_time
+        _op_time_map["PUT"] = _put_time
+
+    # Now group the results by operation type and our bucket sizes
+        _agg_exprs = [
+            (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
+            (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
+            (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
+            (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
+            (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
+            (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
+            (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
+            pl.count("op").alias("count"),
+            pl.col("bytes").sum().alias("bytes_sum"),
+        ]
+        if "thread" in df.columns:
+            _agg_exprs.append(pl.col("thread").n_unique().alias("max_threads"))
+
+        result = df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(_agg_exprs)
+
+        # Compute per-op throughput rates using the correct per-op time range (issue #14)
+        result = result.with_columns(
+            pl.col("op").map_elements(lambda op: _op_time_map.get(op, run_time_secs), return_dtype=pl.Float64).alias("runtime_s")
+        ).with_columns([
+            (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
+            (pl.col("bytes_sum").cast(pl.Float64) / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
+        ]).drop(["bytes_sum"])
+
+        # Ensure throughput is in Float64 format for consistency
+        result = result.with_columns(pl.col("xput_MBps").cast(pl.Float64))
+
+        # Calculate throughput metrics for the current file (used in multi-file consolidation)
+        throughput_metrics = df.group_by("op", "bytes_bucket").agg([
+            ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
+            pl.count("op").alias("count"),
+        ])
+
+        # Ensure 'op' column is of type Utf8
+        throughput_metrics = throughput_metrics.with_columns(pl.col("op").cast(pl.Utf8))
+
+        final_result = result.sort(["bucket_#", "op"])
+
+        # Filter out rows with zero count (empty buckets or invalid data)
+        final_result = final_result.filter(pl.col("count") > 0)
+
+        # Reorder columns (runtime_s last)
+        _col_order = ["op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
+                      "90%_lat_us", "95%_lat_us", "99%_lat_us", "max_lat_us",
+                      "avg_obj_KB", "ops_/_sec", "xput_MBps", "count", "max_threads", "runtime_s"]
+        final_result = final_result.select([c for c in _col_order if c in final_result.columns])
+
+        final_result_pd = final_result.to_pandas()
+
+    # List of columns to send to the pretty comma-fyer
+        columns_to_format = [
+            "med._lat_us",
+            "90%_lat_us",
+            "95%_lat_us",
+            "99%_lat_us",
+            "mean_lat_us",
+            "max_lat_us",
+            "ops_/_sec",
+            "count",
+            "avg_obj_KB",
+            "xput_MBps",
+        ]
+        for column in columns_to_format:
+            if column in final_result_pd:
+                final_result_pd[column] = final_result_pd[column].map(format_with_commas)
+        if "runtime_s" in final_result_pd:
+            final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(lambda x: f"{x:.1f}")
+
+        print(final_result_pd.to_string(index=False))
+
+        # Print summary rows for META, GET, PUT (with statistically valid percentiles)
+        summary_rows = compute_summary_rows(df, run_time_secs)
+        print_summary_rows(summary_rows, columns_to_format)
+
+        # Print per-client statistics if requested
+        if per_client_stats:
+            compute_per_client_stats(df, run_time_secs)
+
+        # Print per-endpoint statistics if requested (issue #15)
+        if per_endpoint_stats:
+            compute_per_endpoint_stats(df, run_time_secs)
+
+        # Print processing time (matching Rust output)
+        process_elapsed = time.time() - process_start
+        print(f"\nProcessed in {process_elapsed:.2f} seconds")
+
+        # Save data for Excel export
+        if excel_path is not None:
+            saved_file_dfs.append({'path': file_path, 'df': df, 'run_secs': run_time_secs})
+
+        consolidated_df = pl.concat([consolidated_df, df])
+
+        # Append the metrics to consolidated_throughputs
+        #consolidated_throughput_df = pl.concat([consolidated_throughput_df, throughput_metrics])
+        consolidated_throughputs.append(throughput_metrics)
+
+
+    # Done processing each file
+
+    # Warn if user mixed trace and summary files
+    if any_trace_file and any_summary_file:
+        print(
+            "WARNING: Mixed trace and summary files provided.  "
+            "Consolidation is skipped for summary files; each is reported independently.",
+            file=sys.stderr,
+        )
+
+    # If only summary files were provided, write Excel if needed and exit now
+    if not any_trace_file:
+        if excel_path is not None:
+            write_polarwarp_excel(
+                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                summary_file_data=summary_file_data,
             )
-            required_summary = ["op", "start", "end", "bps", "ops_per_sec", "errors"]
-            missing_s = [c for c in required_summary if c not in summary_df.columns]
-            if missing_s:
-                print_error(f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}")
-            summary_df = summary_df.with_columns([
-                pl.col("bps").cast(pl.Float64),
-                pl.col("ops_per_sec").cast(pl.Float64),
-            ])
-            seg_count = summary_df.height
-            start_val = summary_df.select(pl.col("start").first()).item()
-            end_val   = summary_df.select(pl.col("end").last()).item()
-            print(f"Time range: {start_val} → {end_val}  ({seg_count} segments)")
-            compute_and_display_summary_stats(summary_df)
-            if excel_path is not None:
-                summary_file_data.append({'path': file_path, 'df': summary_df})
-            process_elapsed = time.time() - process_start
-            print(f"\nProcessed in {process_elapsed:.2f} seconds")
-            continue
+        sys.exit(0)
 
-        any_trace_file = True
+    # If there was only one file to parse, write Excel if requested, then exit
+    if len(file_paths) == 1:
+        if excel_path is not None:
+            write_polarwarp_excel(
+                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                summary_file_data=summary_file_data,
+            )
+        sys.exit(0)
 
-        # Try to read the file with error handling
-        # glob=False prevents polars from treating brackets in filenames as glob patterns
-        try:
-            df = pl.read_csv(file_path, ignore_errors=True, separator='\t', glob=False)
-        except Exception as e:
-            print_error(f"Failed to read file '{file_path}': {e}")
-        
-        # Check if dataframe is empty
-        if df.is_empty():
-            print_error(f"File '{file_path}' contains no data")
-        
-        # Check for required columns
-        required_columns = ["start", "end", "op", "bytes", "duration_ns"]
-        missing_columns = [col for col in required_columns if col not in df.columns]
-        if missing_columns:
-            print_error(f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}")
+    print(f"\nDone Processing Files... Consolidating Results")
 
-        # Note: parsing the ISO 8601 time is a bit tricky.  If the value ends in a literal capital "Z", then it may cause problems.  
-        try:
-            df = df.with_columns([
-                pl.col("start").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("start"),
-                pl.col("end").str.replace("Z$", "+00:00").str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False).alias("end"),
-            ])
-        except Exception as e:
-            print_error(f"Failed to parse timestamps in file '{file_path}': {e}")
+    # Compute overlap (latest-start / earliest-end) and union (earliest-start / latest-end)
+    # across all files. Jaccard = overlap / union is in [0, 100%].
+    for fp, fs, fe in file_ranges:
+        print(f"  File time range: {fp}  (duration: {fe - fs})")
 
-        start_time = None
-        start_values_checked = []
-        for value in df.select(pl.col("start").drop_nulls()).to_series():
-            start_values_checked.append(value)
-            if value is not None:
-                start_time = value
-                break
+    overlap_start = max(r[1] for r in file_ranges)
+    overlap_end   = min(r[2] for r in file_ranges)
+    union_start   = min(r[1] for r in file_ranges)
+    union_end     = max(r[2] for r in file_ranges)
 
-        end_time = None
-        end_values_checked = []
-        for value in reversed(df.select(pl.col("end").drop_nulls()).to_series()):
-            end_values_checked.append(value)
-            if value is not None:
-                end_time = value
-                break
+    overlap_secs = max(0.0, (overlap_end - overlap_start).total_seconds())
+    union_secs   = (union_end - union_start).total_seconds()
+    jaccard_pct  = (overlap_secs / union_secs * 100.0) if union_secs > 0 and overlap_secs > 0 else 0.0
 
-        # If this error is raised, likely a time parsing issue
-        if start_time is None or end_time is None:
-            print_error(f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)")
-    
-    except KeyboardInterrupt:
-        print("\n\nInterrupted by user", file=sys.stderr)
-        sys.exit(130)
-    except Exception as e:
-        print_error(f"Unexpected error processing file '{file_path}': {e}")
+    print(f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)")
+    print(f"  Jaccard overlap: {jaccard_pct:.1f}%  (overlap / union)")
 
-    # Per-file effective start (accounting for skip) and duration
-    file_start = (start_time + skip_time) if skip_time is not None else start_time
-    run_time = end_time - file_start
-    run_time_secs = run_time.total_seconds()
-    file_ranges.append((file_path, file_start, end_time))
+    if jaccard_pct < OVERLAP_MIN_PCT:
+        print(f"WARNING: Files appear to be sequential runs "
+              f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold).")
+        print("  Skipping consolidation \u2013 per-file results above are still valid.")
+        if excel_path is not None:
+            write_polarwarp_excel(
+                excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+                summary_file_data=summary_file_data,
+            )
+        sys.exit(0)
 
-    if skip_time is not None:
-        threshold_time = start_time + skip_time
-        print(f"Skipping rows with 'start' <= {threshold_time}.")
-        df = df.filter(pl.col("start") > threshold_time)
+    if jaccard_pct < OVERLAP_MAX_PCT:
+        print(f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  "
+              f"Filtering all files to overlap window before consolidating.")
+    else:
+        print(f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window.")
 
-    print(f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}")
+    # Filter consolidated_df to only operations whose start falls within the overlap window.
+    # This ensures counts and throughput are computed over the same time slice across all files.
+    consolidated_df = consolidated_df.filter(
+        (pl.col("start") >= overlap_start) & (pl.col("start") < overlap_end)
+    )
 
-# Define the bucket order (matching sai3-bench/polarwarp-rs)
-    bucket_order = ["zero", "1B-8KiB", "8KiB-64KiB", "64KiB-512KiB", "512KiB-4MiB", "4MiB-32MiB", "32MiB-256MiB", "256MiB-2GiB", ">2GiB"]
+    if consolidated_df.is_empty():
+        print("No valid data in overlap window to consolidate.")
+        sys.exit(1)
 
-# Size bucket boundaries (matching sai3-bench)
-    BUCKET_8K = 8 * 1024           # 8 KiB
-    BUCKET_64K = 64 * 1024         # 64 KiB
-    BUCKET_512K = 512 * 1024       # 512 KiB
-    BUCKET_4M = 4 * 1024 * 1024    # 4 MiB
-    BUCKET_32M = 32 * 1024 * 1024  # 32 MiB
-    BUCKET_256M = 256 * 1024 * 1024  # 256 MiB
-    BUCKET_2G = 2 * 1024 * 1024 * 1024  # 2 GiB
+    consolidated_run_time = overlap_end - overlap_start
+    consolidated_run_secs = overlap_secs
+    print(f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}")
 
-# Create buckets for byte ranges (matching sai3-bench bucket definitions)
-    df = df.with_columns([
-        pl.when(pl.col("bytes") == 0).then(pl.lit("zero"))
-        .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(pl.lit("1B-8KiB"))
-        .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(pl.lit("8KiB-64KiB"))
-        .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(pl.lit("64KiB-512KiB"))
-        .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(pl.lit("512KiB-4MiB"))
-        .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(pl.lit("4MiB-32MiB"))
-        .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(pl.lit("32MiB-256MiB"))
-        .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(pl.lit("256MiB-2GiB"))
-        .otherwise(pl.lit(">2GiB")).alias("bytes_bucket"),
-        pl.when(pl.col("bytes") == 0).then(0)
-        .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(1)
-        .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(2)
-        .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(3)
-        .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(4)
-        .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(5)
-        .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(6)
-        .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(7)
-        .otherwise(8).alias("bucket_#")
-    ])
+    # Adjust consolidated_stats to join on both "op" and "bytes_bucket"
+    if consolidated_df.is_empty():
+        print("No valid data to consolidate.")
+        sys.exit(1)
 
-# Pre-compute per-operation time ranges (issue #14: correct for non-overlapping workloads)
-    def _op_time(op_df):
-        if op_df.height == 0:
-            return run_time_secs
-        min_s = op_df.select(pl.col("start").min()).item()
-        max_e = op_df.select(pl.col("end").max()).item()
-        if min_s is None or max_e is None:
-            return run_time_secs
-        dt = (max_e - min_s).total_seconds()
-        return dt if dt > 0.001 else run_time_secs
-
-    _meta_time = _op_time(df.filter(pl.col("op").is_in(META_OPS)))
-    _get_time  = _op_time(df.filter(pl.col("op") == "GET"))
-    _put_time  = _op_time(df.filter(pl.col("op") == "PUT"))
-
-    # Build op -> run_time mapping
-    _op_time_map = {op: _meta_time for op in META_OPS}
-    _op_time_map["GET"] = _get_time
-    _op_time_map["PUT"] = _put_time
-
-# Now group the results by operation type and our bucket sizes
-    _agg_exprs = [
+    consolidated_stats = consolidated_df.group_by(["op", "bytes_bucket", "bucket_#"]).agg([
         (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
         (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
         (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
         (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
         (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-        (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
         (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-        pl.count("op").alias("count"),
-        pl.col("bytes").sum().alias("bytes_sum"),
-    ]
-    if "thread" in df.columns:
-        _agg_exprs.append(pl.col("thread").n_unique().alias("max_threads"))
-
-    result = df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(_agg_exprs)
-
-    # Compute per-op throughput rates using the correct per-op time range (issue #14)
-    result = result.with_columns(
-        pl.col("op").map_elements(lambda op: _op_time_map.get(op, run_time_secs), return_dtype=pl.Float64).alias("runtime_s")
-    ).with_columns([
-        (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
-        (pl.col("bytes_sum").cast(pl.Float64) / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
-    ]).drop(["bytes_sum"])
-
-    # Ensure throughput is in Float64 format for consistency
-    result = result.with_columns(pl.col("xput_MBps").cast(pl.Float64))
-
-    # Calculate throughput metrics for the current file (used in multi-file consolidation)
-    throughput_metrics = df.group_by("op", "bytes_bucket").agg([
-        ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
-        pl.count("op").alias("count"),
+        pl.count("op").alias("tot_count"),
     ])
 
-    # Ensure 'op' column is of type Utf8
-    throughput_metrics = throughput_metrics.with_columns(pl.col("op").cast(pl.Utf8))
 
-    final_result = result.sort(["bucket_#", "op"])
+    # Combine all throughput metrics into a single DataFrame, grouped by "op" and "bytes_bucket"
+    if consolidated_throughputs:
+        combined_throughputs = pl.concat(consolidated_throughputs).group_by(["op", "bytes_bucket"]).agg([
+            pl.col("xput_MBps").sum().alias("total_xput_MBps"),
+            (pl.col("count").sum() / consolidated_run_secs).alias("tot_ops_/_sec"),
+        ])
+    else:
+        combined_throughputs = pl.DataFrame({
+            "op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []
+        })
 
-    # Filter out rows with zero count (empty buckets or invalid data)
-    final_result = final_result.filter(pl.col("count") > 0)
+    # Join consolidated throughput metrics on "op" and "bytes_bucket"
+    consolidated_stats = consolidated_stats.join(combined_throughputs, on=["op", "bytes_bucket"], how="left")
+    consolidated_stats = consolidated_stats.sort(["bucket_#", "op"])
 
-    # Reorder columns (runtime_s last)
-    _col_order = ["op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
-                  "90%_lat_us", "95%_lat_us", "99%_lat_us", "max_lat_us",
-                  "avg_obj_KB", "ops_/_sec", "xput_MBps", "count", "max_threads", "runtime_s"]
-    final_result = final_result.select([c for c in _col_order if c in final_result.columns])
+    # Ensure all expected columns are present and in the desired order
+    desired_column_order = [
+        "op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
+        "90%_lat_us", "95%_lat_us", "99%_lat_us", "avg_obj_KB",
+        "tot_ops_/_sec", "total_xput_MBps", "tot_count",
+    ]
 
-    final_result_pd = final_result.to_pandas()
+    consolidated_stats = consolidated_stats.select(desired_column_order).sort(["bucket_#", "op"])
 
-# List of columns to send to the pretty comma-fyer
+    # Convert to pandas for final output formatting
+    consolidated_stats_pd = consolidated_stats.to_pandas()
+
     columns_to_format = [
+        "mean_lat_us",
         "med._lat_us",
         "90%_lat_us",
         "95%_lat_us",
         "99%_lat_us",
-        "mean_lat_us",
-        "max_lat_us",
-        "ops_/_sec",
-        "count",
         "avg_obj_KB",
-        "xput_MBps",
+        "tot_ops_/_sec",
+        "total_xput_MBps",
+        "tot_count",
     ]
     for column in columns_to_format:
-        if column in final_result_pd:
-            final_result_pd[column] = final_result_pd[column].map(format_with_commas)
-    if "runtime_s" in final_result_pd:
-        final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(lambda x: f"{x:.1f}")
+        if column in consolidated_stats_pd:
+            consolidated_stats_pd[column] = consolidated_stats_pd[column].map(format_with_commas)
 
-    print(final_result_pd.to_string(index=False))
+    print("Consolidated Results:")
+    print(consolidated_stats_pd)
 
-    # Print summary rows for META, GET, PUT (with statistically valid percentiles)
-    summary_rows = compute_summary_rows(df, run_time_secs)
+    # Print summary rows for consolidated results (with statistically valid percentiles)
+    summary_rows = compute_summary_rows(consolidated_df, consolidated_run_secs)
     print_summary_rows(summary_rows, columns_to_format)
 
-    # Print per-client statistics if requested
+    # Print per-client statistics for consolidated data if requested
     if per_client_stats:
-        compute_per_client_stats(df, run_time_secs)
+        compute_per_client_stats(consolidated_df, consolidated_run_secs)
 
-    # Print per-endpoint statistics if requested (issue #15)
+    # Print per-endpoint statistics for consolidated data if requested (issue #15)
     if per_endpoint_stats:
-        compute_per_endpoint_stats(df, run_time_secs)
+        compute_per_endpoint_stats(consolidated_df, consolidated_run_secs)
 
-    # Print processing time (matching Rust output)
-    process_elapsed = time.time() - process_start
-    print(f"\nProcessed in {process_elapsed:.2f} seconds")
-
-    # Save data for Excel export
-    if excel_path is not None:
-        saved_file_dfs.append({'path': file_path, 'df': df, 'run_secs': run_time_secs})
-
-    consolidated_df = pl.concat([consolidated_df, df])
-
-    # Append the metrics to consolidated_throughputs
-    #consolidated_throughput_df = pl.concat([consolidated_throughput_df, throughput_metrics])
-    consolidated_throughputs.append(throughput_metrics)
-
-
-# Done processing each file
-
-# Warn if user mixed trace and summary files
-if any_trace_file and any_summary_file:
-    print(
-        "WARNING: Mixed trace and summary files provided.  "
-        "Consolidation is skipped for summary files; each is reported independently.",
-        file=sys.stderr,
-    )
-
-# If only summary files were provided, write Excel if needed and exit now
-if not any_trace_file:
+    # Write Excel for multi-file run
     if excel_path is not None:
         write_polarwarp_excel(
             excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
+            consolidated_df, consolidated_run_secs,
             summary_file_data=summary_file_data,
         )
-    sys.exit(0)
-
-# If there was only one file to parse, write Excel if requested, then exit
-if len(file_paths) == 1:
-    if excel_path is not None:
-        write_polarwarp_excel(
-            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
-            summary_file_data=summary_file_data,
-        )
-    sys.exit(0)
-
-print(f"\nDone Processing Files... Consolidating Results")
-
-# Compute overlap (latest-start / earliest-end) and union (earliest-start / latest-end)
-# across all files. Jaccard = overlap / union is in [0, 100%].
-for fp, fs, fe in file_ranges:
-    print(f"  File time range: {fp}  (duration: {fe - fs})")
-
-overlap_start = max(r[1] for r in file_ranges)
-overlap_end   = min(r[2] for r in file_ranges)
-union_start   = min(r[1] for r in file_ranges)
-union_end     = max(r[2] for r in file_ranges)
-
-overlap_secs = max(0.0, (overlap_end - overlap_start).total_seconds())
-union_secs   = (union_end - union_start).total_seconds()
-jaccard_pct  = (overlap_secs / union_secs * 100.0) if union_secs > 0 and overlap_secs > 0 else 0.0
-
-print(f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)")
-print(f"  Jaccard overlap: {jaccard_pct:.1f}%  (overlap / union)")
-
-if jaccard_pct < OVERLAP_MIN_PCT:
-    print(f"WARNING: Files appear to be sequential runs "
-          f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold).")
-    print("  Skipping consolidation \u2013 per-file results above are still valid.")
-    if excel_path is not None:
-        write_polarwarp_excel(
-            excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
-            summary_file_data=summary_file_data,
-        )
-    sys.exit(0)
-
-if jaccard_pct < OVERLAP_MAX_PCT:
-    print(f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  "
-          f"Filtering all files to overlap window before consolidating.")
-else:
-    print(f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window.")
-
-# Filter consolidated_df to only operations whose start falls within the overlap window.
-# This ensures counts and throughput are computed over the same time slice across all files.
-consolidated_df = consolidated_df.filter(
-    (pl.col("start") >= overlap_start) & (pl.col("start") < overlap_end)
-)
-
-if consolidated_df.is_empty():
-    print("No valid data in overlap window to consolidate.")
-    sys.exit(1)
-
-consolidated_run_time = overlap_end - overlap_start
-consolidated_run_secs = overlap_secs
-print(f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}")
-
-# Adjust consolidated_stats to join on both "op" and "bytes_bucket"
-if consolidated_df.is_empty():
-    print("No valid data to consolidate.")
-    sys.exit(1)
-
-consolidated_stats = consolidated_df.group_by(["op", "bytes_bucket", "bucket_#"]).agg([
-    (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
-    (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
-    (pl.col("duration_ns").quantile(0.90) / 1000).alias("90%_lat_us"),
-    (pl.col("duration_ns").quantile(0.95) / 1000).alias("95%_lat_us"),
-    (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
-    (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
-    pl.count("op").alias("tot_count"),
-])
-
-
-# Combine all throughput metrics into a single DataFrame, grouped by "op" and "bytes_bucket"
-if consolidated_throughputs:
-    combined_throughputs = pl.concat(consolidated_throughputs).group_by(["op", "bytes_bucket"]).agg([
-        pl.col("xput_MBps").sum().alias("total_xput_MBps"),
-        (pl.col("count").sum() / consolidated_run_secs).alias("tot_ops_/_sec"),
-    ])
-else:
-    combined_throughputs = pl.DataFrame({
-        "op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []
-    })
-
-# Join consolidated throughput metrics on "op" and "bytes_bucket"
-consolidated_stats = consolidated_stats.join(combined_throughputs, on=["op", "bytes_bucket"], how="left")
-consolidated_stats = consolidated_stats.sort(["bucket_#", "op"])
-
-# Ensure all expected columns are present and in the desired order
-desired_column_order = [
-    "op", "bytes_bucket", "bucket_#", "mean_lat_us", "med._lat_us",
-    "90%_lat_us", "95%_lat_us", "99%_lat_us", "avg_obj_KB",
-    "tot_ops_/_sec", "total_xput_MBps", "tot_count",
-]
-
-consolidated_stats = consolidated_stats.select(desired_column_order).sort(["bucket_#", "op"])
-
-# Convert to pandas for final output formatting
-consolidated_stats_pd = consolidated_stats.to_pandas()
-
-columns_to_format = [
-    "mean_lat_us",
-    "med._lat_us",
-    "90%_lat_us",
-    "95%_lat_us",
-    "99%_lat_us",
-    "avg_obj_KB",
-    "tot_ops_/_sec",
-    "total_xput_MBps",
-    "tot_count",
-]
-for column in columns_to_format:
-    if column in consolidated_stats_pd:
-        consolidated_stats_pd[column] = consolidated_stats_pd[column].map(format_with_commas)
-
-print("Consolidated Results:")
-print(consolidated_stats_pd)
-
-# Print summary rows for consolidated results (with statistically valid percentiles)
-summary_rows = compute_summary_rows(consolidated_df, consolidated_run_secs)
-print_summary_rows(summary_rows, columns_to_format)
-
-# Print per-client statistics for consolidated data if requested
-if per_client_stats:
-    compute_per_client_stats(consolidated_df, consolidated_run_secs)
-
-# Print per-endpoint statistics for consolidated data if requested (issue #15)
-if per_endpoint_stats:
-    compute_per_endpoint_stats(consolidated_df, consolidated_run_secs)
-
-# Write Excel for multi-file run
-if excel_path is not None:
-    write_polarwarp_excel(
-        excel_path, saved_file_dfs, per_client_stats, per_endpoint_stats,
-        consolidated_df, consolidated_run_secs,
-        summary_file_data=summary_file_data,
-    )

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -440,6 +440,114 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                         drow += 1
                         drow = _write_df(ws, op_ep, startrow=drow)
 
+        def _build_timeseries_pd(sdf):
+            """Build wide-format time-series data from a summary DataFrame.
+
+            Filters TOTAL rows, parses start timestamps, computes seconds-from-start,
+            and pivots so each op type becomes its own ops_per_sec and MBps columns.
+
+            Returns (ts_pd, ops_list):
+              - ts_pd:    pandas DataFrame with columns [seconds, <op>_ops…, <op>_MBps…]
+              - ops_list: sorted list of non-TOTAL op names present in the data
+            """
+            df_filt = sdf.filter(pl.col("op") != "TOTAL")
+            if df_filt.height == 0:
+                return None, []
+
+            # Parse ISO-8601 start strings to UTC datetimes, then compute
+            # seconds-from-first-interval as an integer offset.
+            df_filt = df_filt.with_columns(
+                pl.col("start").str.to_datetime(
+                    strict=False, time_unit="us", time_zone="UTC"
+                ).alias("start_dt")
+            )
+            min_start = df_filt.select(pl.col("start_dt").min()).item()
+            df_filt = df_filt.with_columns([
+                (
+                    (pl.col("start_dt") - min_start).dt.total_microseconds() / 1_000_000.0
+                ).round(0).cast(pl.Int64).alias("seconds"),
+                (pl.col("bps") / 1_048_576.0).alias("MBps"),
+            ])
+
+            ops_list = sorted(df_filt.select(pl.col("op").unique()).to_series().to_list())
+
+            # Pivot ops_per_sec and MBps so each op becomes a column.
+            ops_pivot = df_filt.pivot(
+                on="op", index="seconds", values="ops_per_sec", aggregate_function="mean"
+            )
+            ops_pivot = ops_pivot.rename(
+                {op: f"{op}_ops" for op in ops_list if op in ops_pivot.columns}
+            )
+
+            bw_pivot = df_filt.pivot(
+                on="op", index="seconds", values="MBps", aggregate_function="mean"
+            )
+            bw_pivot = bw_pivot.rename(
+                {op: f"{op}_MBps" for op in ops_list if op in bw_pivot.columns}
+            )
+
+            ts_df = ops_pivot.join(bw_pivot, on="seconds", how="full", coalesce=True).sort("seconds")
+            return ts_df.to_pandas(), ops_list
+
+        def _write_summary_chart_tab(wb, sdf, chart_tab_name):
+            """Write a time-series data tab with ops/sec and throughput line charts.
+
+            Produces two side-by-side line charts below the pivot data table:
+              1. Operations/sec over Time (GET, PUT, META series)
+              2. Throughput MiB/s over Time (GET, PUT only — META has no bandwidth)
+            """
+            ts_pd, ops_list = _build_timeseries_pd(sdf)
+            if ts_pd is None or ts_pd.empty:
+                return
+
+            ws = wb.add_worksheet(chart_tab_name)
+            n_rows = len(ts_pd)
+
+            # Write pivot data (header + rows) starting at row 0
+            _write_df(ws, ts_pd, startrow=0)
+
+            cols = list(ts_pd.columns)  # ['seconds', 'GET_ops', …, 'GET_MBps', …]
+            sec_ci = cols.index('seconds')
+
+            # ── Chart 1: ops/sec over time ──────────────────────────────────────
+            chart_ops = wb.add_chart({'type': 'line'})
+            for op in ops_list:
+                col_name = f"{op}_ops"
+                if col_name in cols:
+                    ci = cols.index(col_name)
+                    chart_ops.add_series({
+                        'name':       op,
+                        'categories': [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
+                        'values':     [chart_tab_name, 1, ci,     n_rows, ci],
+                    })
+            chart_ops.set_title({'name': 'Operations/sec over Time'})
+            chart_ops.set_x_axis({'name': 'Seconds'})
+            chart_ops.set_y_axis({'name': 'ops/sec'})
+            chart_ops.set_legend({'position': 'bottom'})
+
+            # ── Chart 2: throughput (MiB/s) — GET and PUT only ─────────────────
+            chart_bw = wb.add_chart({'type': 'line'})
+            for op in (o for o in ops_list if o in ('GET', 'PUT')):
+                col_name = f"{op}_MBps"
+                if col_name in cols:
+                    ci = cols.index(col_name)
+                    chart_bw.add_series({
+                        'name':       op,
+                        'categories': [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
+                        'values':     [chart_tab_name, 1, ci,     n_rows, ci],
+                    })
+            chart_bw.set_title({'name': 'Throughput (MiB/s) over Time'})
+            chart_bw.set_x_axis({'name': 'Seconds'})
+            chart_bw.set_y_axis({'name': 'MiB/s'})
+            chart_bw.set_legend({'position': 'bottom'})
+
+            # Place both charts below the data, side by side
+            chart_row = n_rows + 3
+            if any(f"{op}_ops" in cols for op in ops_list):
+                ws.insert_chart(chart_row, 0, chart_ops)
+            if any(f"{op}_MBps" in cols for op in ('GET', 'PUT')):
+                ws.insert_chart(chart_row, 8, chart_bw)
+
         # Pre-compute unique short names to avoid worksheet name collisions when
         # multiple files share the same prefix after truncation to 20 characters.
         if single:
@@ -487,6 +595,8 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
             for entry in summary_file_data:
                 sfp, sdf = entry['path'], entry['df']
                 short = _short(sfp)
+
+                # Summary statistics tab (aggregate stats per op)
                 tab_name = _tab(short, 'Summary')
                 ws = wb.add_worksheet(tab_name)
                 stats_pl = _compute_summary_stats_df(sdf)
@@ -494,6 +604,9 @@ def write_polarwarp_excel(excel_path, saved_files, per_client, per_endpoint,
                 # Keep only columns that exist (guard against schema changes)
                 ordered = [c for c in summary_cols if c in stats_pd.columns]
                 _write_df(ws, stats_pd[ordered], startrow=0)
+
+                # Charts tab (time-series line charts)
+                _write_summary_chart_tab(wb, sdf, _tab(short, 'Charts'))
 
         wb.close()
         print(f"\nExcel file written: {excel_path}")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,3 +10,9 @@ dependencies = [
     "pyarrow>=23.0.1",
     "xlsxwriter>=3.2.9",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "zstandard>=0.23",
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,6 +13,42 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pylint>=4.0.5",
     "pytest>=8.0",
+    "ruff>=0.15.13",
     "zstandard>=0.23",
 ]
+
+[tool.pylint.messages_control]
+# By-design patterns that are not bugs:
+disable = [
+    # Large single-module design: all logic is intentionally in one file / one function
+    "too-many-lines",          # C0302 — single-file tool by design
+    "too-many-statements",     # R0915 — write_polarwarp_excel is intentionally large
+    "too-many-branches",       # R0912
+    "too-many-locals",         # R0914
+    "too-many-arguments",      # R0913
+    "too-many-positional-arguments",  # R0917
+    # UPPER_CASE names are the standard Python convention for module-level constants
+    "invalid-name",            # C0103 — BUCKET_* names are intentional constants
+    # Inner functions intentionally reuse parameter names from outer scope
+    "redefined-outer-name",    # W0621
+    # Lazy imports for optional / heavy dependencies (xlsxwriter, pandas)
+    "import-outside-toplevel", # C0415
+    # val != val is an intentional NaN check (polars/pandas idiom)
+    "comparison-with-itself",  # R0124
+    # Broad exception catching is intentional defensive I/O error handling
+    "broad-exception-caught",  # W0718
+    # Docstrings: not required for this single-file utility
+    "missing-module-docstring",   # C0114
+    "missing-function-docstring", # C0116
+]
+
+[tool.pylint.format]
+max-line-length = 140
+
+[tool.ruff]
+line-length = 140
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polarwarp"
-version = "0.1.6"
+version = "0.1.7"
 description = "A Python implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polarwarp"
-version = "0.1.7"
+version = "0.2.0"
 description = "A Python implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/tests/test_polarwarp.py
+++ b/python/tests/test_polarwarp.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: 2025 Russ Fellows <russ.fellows@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for polarwarp.py — Python equivalents of the Rust polarwarp-rs tests.
+
+polarwarp.py is a script with top-level execution guarded by `if __name__ == "__main__":`.
+We load it via importlib so the guard prevents the script body from running, giving
+us clean access to all module-level helper functions.
+"""
+import importlib.util
+import os
+import re
+import sys
+import tempfile
+import zstandard as zstd
+import pytest
+import polars as pl
+from datetime import timedelta
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module fixture — load polarwarp.py once for the whole test session
+# ---------------------------------------------------------------------------
+
+_MODULE_PATH = Path(__file__).parent.parent / "polarwarp.py"
+
+
+@pytest.fixture(scope="session")
+def pw():
+    """Return the polarwarp module loaded via importlib (no script execution)."""
+    spec = importlib.util.spec_from_file_location("polarwarp", str(_MODULE_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# format_with_commas — float / int / non-numeric
+# ---------------------------------------------------------------------------
+
+class TestFormatWithCommas:
+    def test_zero_float(self, pw):
+        assert pw.format_with_commas(0.0) == "0.00"
+
+    def test_thousands_float(self, pw):
+        assert pw.format_with_commas(1000.0) == "1,000.00"
+
+    def test_large_float(self, pw):
+        assert pw.format_with_commas(1_234_567.0) == "1,234,567.00"
+
+    def test_fractional_float(self, pw):
+        assert pw.format_with_commas(1024.75) == "1,024.75"
+
+    def test_int_small(self, pw):
+        assert pw.format_with_commas(42) == "42"
+
+    def test_int_million(self, pw):
+        assert pw.format_with_commas(1_000_000) == "1,000,000"
+
+    def test_non_numeric_string(self, pw):
+        assert pw.format_with_commas("hello") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# _excel_derive_path — single-file stem vs. multi-file fallback
+# ---------------------------------------------------------------------------
+
+class TestExcelDerivePath:
+    def test_single_tsv_zst(self, pw):
+        result = pw._excel_derive_path(["output/run1.trace.tsv.zst"])
+        assert result == "output/run1.trace.xlsx"
+
+    def test_single_plain_tsv(self, pw):
+        result = pw._excel_derive_path(["results.tsv"])
+        assert result == os.path.join(".", "results.xlsx")
+
+    def test_single_csv_zst(self, pw):
+        result = pw._excel_derive_path(["data/bench.csv.zst"])
+        assert result == "data/bench.xlsx"
+
+    def test_multiple_files(self, pw):
+        result = pw._excel_derive_path(["a.tsv.zst", "b.tsv.zst"])
+        assert result == "polarwarp-results.xlsx"
+
+    def test_multiple_files_three(self, pw):
+        result = pw._excel_derive_path(["x.tsv.zst", "y.tsv.zst", "z.tsv.zst"])
+        assert result == "polarwarp-results.xlsx"
+
+
+# ---------------------------------------------------------------------------
+# Short-name / tab-name helpers (replicated from write_polarwarp_excel locals)
+# These mirror the Rust derive_short_name and make_tab_name tests.
+# ---------------------------------------------------------------------------
+
+def _short(fp: str) -> str:
+    """Replicate write_polarwarp_excel._short logic."""
+    n = os.path.basename(fp)
+    n = n.removesuffix('.zst')
+    n = n.removesuffix('.csv') if n.endswith('.csv') else \
+        n.removesuffix('.tsv') if n.endswith('.tsv') else n
+    bi = n.find('[')
+    if bi >= 0:
+        n = n[:bi]
+    return n.rstrip('-_.')[:20]
+
+
+def _tab(base: str, suf: str) -> str:
+    """Replicate write_polarwarp_excel._tab logic."""
+    full = f"{base}-{suf}"
+    return full if len(full) <= 31 else f"{base[:31-len(suf)-1]}-{suf}"
+
+
+class TestShortName:
+    def test_tsv_zst_extension_stripped(self):
+        assert _short("output/run1.trace.tsv.zst") == "run1.trace"
+
+    def test_plain_csv_extension_stripped(self):
+        assert _short("results.csv") == "results"
+
+    def test_bracket_timestamp_stripped(self):
+        # warp output files contain [2024-01-15T10:30:00Z] timestamp brackets
+        assert _short("bench[2024-01-15T10:30:00Z].tsv.zst") == "bench"
+
+    def test_truncated_to_20_chars(self):
+        long_name = "averylongunambiguousname.tsv.zst"
+        result = _short(long_name)
+        assert len(result) <= 20
+
+
+class TestTabName:
+    def test_short_name_unchanged(self):
+        assert _tab("run1", "Results") == "run1-Results"
+
+    def test_combined_within_31_chars(self):
+        result = _tab("short", "Detail")
+        assert result == "short-Detail"
+        assert len(result) <= 31
+
+    def test_truncated_to_31_chars(self):
+        base = "x" * 30  # very long base
+        result = _tab(base, "Results")
+        assert len(result) == 31
+
+    def test_truncated_preserves_suffix(self):
+        base = "y" * 30
+        result = _tab(base, "Summary")
+        assert result.endswith("-Summary")
+        assert len(result) == 31
+
+
+# ---------------------------------------------------------------------------
+# Skip-time pattern parsing — equivalent to Rust parse_skip_time tests
+# ---------------------------------------------------------------------------
+
+_SKIP_PATTERN = re.compile(r"^--skip=(\d+)([sm])$")
+
+
+class TestSkipPattern:
+    def test_seconds(self):
+        m = _SKIP_PATTERN.match("--skip=90s")
+        assert m is not None
+        assert m.group(1) == "90"
+        assert m.group(2) == "s"
+        assert timedelta(seconds=int(m.group(1))) == timedelta(seconds=90)
+
+    def test_minutes(self):
+        m = _SKIP_PATTERN.match("--skip=5m")
+        assert m is not None
+        assert m.group(1) == "5"
+        assert m.group(2) == "m"
+        assert timedelta(minutes=int(m.group(1))) == timedelta(minutes=5)
+
+    def test_zero_seconds(self):
+        m = _SKIP_PATTERN.match("--skip=0s")
+        assert m is not None
+        assert timedelta(seconds=0) == timedelta(seconds=0)
+
+    def test_invalid_unit_hours(self):
+        assert _SKIP_PATTERN.match("--skip=2h") is None
+
+    def test_invalid_no_prefix(self):
+        assert _SKIP_PATTERN.match("skip=5s") is None
+
+    def test_invalid_no_value(self):
+        assert _SKIP_PATTERN.match("--skip=s") is None
+
+
+# ---------------------------------------------------------------------------
+# timedelta formatting — Python equivalent of Rust format_duration_ns tests
+# ---------------------------------------------------------------------------
+
+class TestTimedeltaFormatting:
+    """Python uses str(timedelta) which produces H:MM:SS or H:MM:SS.ffffff."""
+
+    def test_zero(self):
+        assert str(timedelta(seconds=0)) == "0:00:00"
+
+    def test_one_second(self):
+        assert str(timedelta(seconds=1)) == "0:00:01"
+
+    def test_one_minute(self):
+        assert str(timedelta(seconds=60)) == "0:01:00"
+
+    def test_one_hour(self):
+        assert str(timedelta(hours=1)) == "1:00:00"
+
+    def test_ninety_seconds(self):
+        assert str(timedelta(seconds=90)) == "0:01:30"
+
+
+# ---------------------------------------------------------------------------
+# detect_file_type — requires real files on disk
+# ---------------------------------------------------------------------------
+
+def _write_tsv(path: str, header: str, row: str) -> None:
+    """Write a minimal 2-line TSV (header + one data row) to path."""
+    with open(path, "w") as f:
+        f.write(header + "\n")
+        f.write(row + "\n")
+
+
+class TestDetectFileType:
+    def test_trace_file(self, pw, tmp_path):
+        p = tmp_path / "sample.tsv"
+        _write_tsv(
+            str(p),
+            "op\tstart\tend\tduration_ns\tbytes\terror",
+            "GET\t2024-01-01T00:00:00Z\t2024-01-01T00:00:01Z\t1000000000\t65536\t",
+        )
+        assert pw.detect_file_type(str(p)) == "trace"
+
+    def test_summary_file(self, pw, tmp_path):
+        p = tmp_path / "summary.tsv"
+        _write_tsv(
+            str(p),
+            "op\tbps\tops_per_sec\terrors",
+            "GET\t1073741824\t100.0\t0",
+        )
+        assert pw.detect_file_type(str(p)) == "summary"
+
+    def test_trace_zst_file(self, pw, tmp_path):
+        """detect_file_type handles .zst files via polars decompression."""
+        p = tmp_path / "sample.tsv.zst"
+        raw = b"op\tstart\tend\tduration_ns\tbytes\terror\nGET\t2024-01-01T00:00:00Z\t2024-01-01T00:00:01Z\t1000000000\t65536\t\n"
+        cctx = zstd.ZstdCompressor()
+        with open(str(p), "wb") as f:
+            f.write(cctx.compress(raw))
+        assert pw.detect_file_type(str(p)) == "trace"
+
+
+# ---------------------------------------------------------------------------
+# _compute_summary_stats_df — aggregation and TOTAL-row ordering
+# ---------------------------------------------------------------------------
+
+def _make_summary_df() -> pl.DataFrame:
+    """Create a small synthetic summary DataFrame for testing."""
+    return pl.DataFrame({
+        "op":          ["GET", "GET", "GET", "PUT", "PUT", "TOTAL", "TOTAL"],
+        "bps":         [
+            1_073_741_824.0,   # 1 GiB/s
+            2_147_483_648.0,   # 2 GiB/s
+            1_610_612_736.0,   # 1.5 GiB/s
+            536_870_912.0,     # 512 MiB/s
+            1_073_741_824.0,   # 1 GiB/s
+            1_342_177_280.0,   # 1.25 GiB/s
+            1_610_612_736.0,   # 1.5 GiB/s
+        ],
+        "ops_per_sec": [100.0, 200.0, 150.0, 50.0, 100.0, 75.0, 100.0],
+        "errors":      [0,     0,     0,     1,    0,     0,    0],
+    })
+
+
+class TestComputeSummaryStatsDf:
+    def test_total_row_is_last(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        last_op = result["op"].to_list()[-1]
+        assert last_op == "TOTAL", f"Expected last row to be TOTAL, got {last_op!r}"
+
+    def test_non_total_rows_before_total(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        ops = result["op"].to_list()
+        total_idx = ops.index("TOTAL")
+        assert all(op != "TOTAL" for op in ops[:total_idx])
+
+    def test_aggregated_row_count(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        # 3 distinct ops: GET, PUT, TOTAL
+        assert result.height == 3
+
+    def test_get_segment_count(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        get_row = result.filter(pl.col("op") == "GET")
+        assert get_row["segments"].item() == 3
+
+    def test_error_sum(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        put_row = result.filter(pl.col("op") == "PUT")
+        assert put_row["total_errors"].item() == 1
+
+    def test_mean_mbps_is_float(self, pw):
+        df = _make_summary_df()
+        result = pw._compute_summary_stats_df(df)
+        mean_val = result.filter(pl.col("op") == "GET")["mean_MBps"].item()
+        assert isinstance(mean_val, float)
+        # GET bps mean is (1G + 2G + 1.5G) / 3 = 1.5 GiB/s = 1536 MiB/s
+        assert abs(mean_val - 1536.0) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Size bucket logic — inline Polars equivalent of Rust add_size_buckets tests
+# ---------------------------------------------------------------------------
+
+BUCKET_8K   = 8 * 1024
+BUCKET_64K  = 64 * 1024
+BUCKET_512K = 512 * 1024
+BUCKET_4M   = 4 * 1024 * 1024
+BUCKET_32M  = 32 * 1024 * 1024
+BUCKET_256M = 256 * 1024 * 1024
+BUCKET_2G   = 2 * 1024 * 1024 * 1024
+
+BUCKET_ORDER = [
+    "zero", "1B-8KiB", "8KiB-64KiB", "64KiB-512KiB",
+    "512KiB-4MiB", "4MiB-32MiB", "32MiB-256MiB", "256MiB-2GiB", ">2GiB",
+]
+
+
+def _apply_buckets(bytes_values: list) -> pl.DataFrame:
+    """Apply the same bucket Polars expressions used in polarwarp.py."""
+    df = pl.DataFrame({"bytes": bytes_values})
+    df = df.with_columns([
+        pl.when(pl.col("bytes") == 0).then(pl.lit("zero"))
+        .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(pl.lit("1B-8KiB"))
+        .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(pl.lit("8KiB-64KiB"))
+        .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(pl.lit("64KiB-512KiB"))
+        .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(pl.lit("512KiB-4MiB"))
+        .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(pl.lit("4MiB-32MiB"))
+        .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(pl.lit("32MiB-256MiB"))
+        .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(pl.lit("256MiB-2GiB"))
+        .otherwise(pl.lit(">2GiB")).alias("bytes_bucket"),
+        pl.when(pl.col("bytes") == 0).then(0)
+        .when((pl.col("bytes") >= 1) & (pl.col("bytes") < BUCKET_8K)).then(1)
+        .when((pl.col("bytes") >= BUCKET_8K) & (pl.col("bytes") < BUCKET_64K)).then(2)
+        .when((pl.col("bytes") >= BUCKET_64K) & (pl.col("bytes") < BUCKET_512K)).then(3)
+        .when((pl.col("bytes") >= BUCKET_512K) & (pl.col("bytes") < BUCKET_4M)).then(4)
+        .when((pl.col("bytes") >= BUCKET_4M) & (pl.col("bytes") < BUCKET_32M)).then(5)
+        .when((pl.col("bytes") >= BUCKET_32M) & (pl.col("bytes") < BUCKET_256M)).then(6)
+        .when((pl.col("bytes") >= BUCKET_256M) & (pl.col("bytes") < BUCKET_2G)).then(7)
+        .otherwise(8).alias("bucket_#"),
+    ])
+    return df
+
+
+class TestSizeBuckets:
+    def test_zero_bytes(self):
+        df = _apply_buckets([0])
+        assert df["bytes_bucket"][0] == "zero"
+        assert df["bucket_#"][0] == 0
+
+    def test_all_bucket_labels(self):
+        """One value from each of the nine buckets maps to the correct label."""
+        inputs = [
+            0,                      # zero
+            1,                      # 1B-8KiB
+            BUCKET_8K,              # 8KiB-64KiB
+            BUCKET_64K,             # 64KiB-512KiB
+            BUCKET_512K,            # 512KiB-4MiB
+            BUCKET_4M,              # 4MiB-32MiB
+            BUCKET_32M,             # 32MiB-256MiB
+            BUCKET_256M,            # 256MiB-2GiB
+            BUCKET_2G,              # >2GiB
+        ]
+        df = _apply_buckets(inputs)
+        assert df["bytes_bucket"].to_list() == BUCKET_ORDER
+
+    def test_bucket_num_matches_label_order(self):
+        """bucket_# must equal the index of bytes_bucket in BUCKET_ORDER."""
+        inputs = [
+            0,
+            1,
+            BUCKET_8K,
+            BUCKET_64K,
+            BUCKET_512K,
+            BUCKET_4M,
+            BUCKET_32M,
+            BUCKET_256M,
+            BUCKET_2G,
+        ]
+        df = _apply_buckets(inputs)
+        for row in df.iter_rows(named=True):
+            label   = row["bytes_bucket"]
+            num     = row["bucket_#"]
+            expected_num = BUCKET_ORDER.index(label)
+            assert num == expected_num, (
+                f"bytes={row['bytes']}: bucket_# {num} != expected {expected_num} "
+                f"for label '{label}'"
+            )
+
+    def test_boundary_values_exclusive(self):
+        """A value of exactly BUCKET_8K belongs to '8KiB-64KiB', not '1B-8KiB'."""
+        df = _apply_buckets([BUCKET_8K - 1, BUCKET_8K])
+        assert df["bytes_bucket"][0] == "1B-8KiB"
+        assert df["bytes_bucket"][1] == "8KiB-64KiB"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -10,6 +10,24 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -71,6 +89,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195 },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -123,6 +150,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "polars"
 version = "1.40.1"
 source = { registry = "https://pypi.org/simple" }
@@ -152,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "polarwarp"
-version = "0.1.6"
+version = "0.1.7"
 source = { virtual = "." }
 dependencies = [
     { name = "pandas" },
@@ -161,12 +197,24 @@ dependencies = [
     { name = "xlsxwriter" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "zstandard" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "polars", specifier = ">=1.38.1" },
     { name = "pyarrow", specifier = ">=23.0.1" },
     { name = "xlsxwriter", specifier = ">=3.2.9" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "zstandard", specifier = ">=0.23" },
 ]
 
 [[package]]
@@ -213,6 +261,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -249,4 +322,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315 },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738 },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436 },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019 },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012 },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148 },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652 },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993 },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806 },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659 },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933 },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008 },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517 },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292 },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237 },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922 },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276 },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679 },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735 },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440 },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070 },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001 },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120 },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230 },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173 },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736 },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368 },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022 },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889 },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952 },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054 },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113 },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936 },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671 },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887 },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658 },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849 },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095 },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751 },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818 },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402 },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108 },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248 },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330 },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123 },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591 },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513 },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118 },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940 },
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -188,7 +188,7 @@ wheels = [
 
 [[package]]
 name = "polarwarp"
-version = "0.1.7"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pandas" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -10,6 +10,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -19,12 +28,39 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733 },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350 },
 ]
 
 [[package]]
@@ -150,6 +186,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -199,7 +244,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pylint" },
     { name = "pytest" },
+    { name = "ruff" },
     { name = "zstandard" },
 ]
 
@@ -213,7 +260,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.15.13" },
     { name = "zstandard", specifier = ">=0.23" },
 ]
 
@@ -270,6 +319,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694 },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -298,12 +365,46 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279 },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798 },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761 },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451 },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285 },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063 },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079 },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486 },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189 },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380 },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605 },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554 },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133 },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455 },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409 },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328 },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1,0 +1,252 @@
+version = 1
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272 },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573 },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782 },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038 },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666 },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480 },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036 },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643 },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117 },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584 },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450 },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933 },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532 },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661 },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539 },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806 },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682 },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810 },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394 },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556 },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311 },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060 },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302 },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407 },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631 },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691 },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241 },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767 },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169 },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477 },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487 },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002 },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353 },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914 },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005 },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974 },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591 },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700 },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781 },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959 },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768 },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181 },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035 },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958 },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020 },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758 },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948 },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325 },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883 },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474 },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500 },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755 },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643 },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846 },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550 },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965 },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600 },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824 },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889 },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463 },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158 },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071 },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690 },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634 },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243 },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659 },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880 },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091 },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282 },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016 },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210 },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126 },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051 },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796 },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741 },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958 },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065 },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101 },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553 },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065 },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188 },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966 },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755 },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658 },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242 },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369 },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306 },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394 },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717 },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897 },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855 },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464 },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723 },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755 },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542 },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104 },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788 },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590 },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564 },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755 },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104 },
+]
+
+[[package]]
+name = "polarwarp"
+version = "0.1.6"
+source = { virtual = "." }
+dependencies = [
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "xlsxwriter" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pandas", specifier = ">=3.0.1" },
+    { name = "polars", specifier = ">=1.38.1" },
+    { name = "pyarrow", specifier = ">=23.0.1" },
+    { name = "xlsxwriter", specifier = ">=3.2.9" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559 },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654 },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394 },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122 },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032 },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490 },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660 },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759 },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471 },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981 },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172 },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733 },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335 },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748 },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554 },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301 },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929 },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365 },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819 },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252 },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127 },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997 },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720 },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852 },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852 },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207 },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117 },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155 },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387 },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102 },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118 },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765 },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890 },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250 },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321 },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315 },
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polarwarp-rs"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 authors = ["Russ Fellows <russ.fellows@gmail.com>"]
 description = "A Rust implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polarwarp-rs"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Russ Fellows <russ.fellows@gmail.com>"]
 description = "A Rust implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"

--- a/rust/MANUAL.md
+++ b/rust/MANUAL.md
@@ -138,10 +138,12 @@ Each workbook contains the following sheets:
 
 | Sheet | Contents |
 |-------|----------|
-| `<filename>-Results` | Full size-bucketed statistics table for one input file |
-| `<filename>-Detail` | Per-endpoint (or per-client) breakdown for one input file |
-| `Consolidated-Results` | Merged results across all files (only present when `>1` file is given) |
-| `Consolidated-Detail` | Merged per-endpoint breakdown (only when `>1` file is given) |
+| `<filename>-Results` | Full size-bucketed statistics table for one trace file |
+| `<filename>-Detail` | Per-endpoint (or per-client) breakdown for one trace file |
+| `Consolidated-Results` | Merged results across all trace files (only present when `>1` file is given) |
+| `Consolidated-Detail` | Merged per-endpoint breakdown (only when `>1` trace file is given) |
+| `<filename>-Summary` | Aggregate throughput statistics per op type for one summary file |
+| `<filename>-Charts` | Per-second time-series data with ops/sec and MiB/s line charts for one summary file |
 
 Detail tabs contain three sections:
 - **Overall** — aggregate per-endpoint stats (all op types combined)
@@ -161,14 +163,21 @@ PolarWarp-rs supports the following file formats:
 - `.csv` - Comma-separated values
 - `.csv.zst` - ZSTD compressed CSV files
 
-The tool automatically detects the separator based on file extension.
+The tool automatically detects the separator based on file extension. The **file type** (trace vs. summary) is auto-detected from the header columns.
 
-### Expected Columns
+### Trace file columns (per-operation oplog)
 
-Oplog files should have these columns (matching sai3-bench format):
 ```
 idx  thread  op  client_id  n_objects  bytes  endpoint  file  error  start  first_byte  end  duration_ns
 ```
+
+### Summary file columns (aggregated time-series)
+
+```
+op  start  end  bps  ops_per_sec  errors
+```
+
+Each row represents one ~1-second time window per operation type (plus a `TOTAL` row). An optional `# cmdline …` comment before the header is ignored.
 
 ## Performance Expectations
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # PolarWarp - Rust Implementation
 
-[![Version](https://img.shields.io/badge/version-0.1.6-blue.svg)](Cargo.toml)
+[![Version](https://img.shields.io/badge/version-0.1.7-blue.svg)](Cargo.toml)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
 
@@ -15,6 +15,7 @@ Built with [Polars](https://pola.rs/) for blazing-fast DataFrame operations, pol
 ## Features
 
 - **Multi-format support**: TSV and CSV files, with automatic zstd decompression and separator detection
+- **Dual file type support**: Per-operation trace files (`.trace.tsv.zst`) *and* aggregated summary files (`.summary.tsv.zst`) — type auto-detected from header columns
 - **Size-bucketed analysis**: 9 size buckets matching sai3-bench (zero, 1B-8KiB, 8KiB-64KiB, ... >2GiB)
 - **Summary rows**: Aggregate statistics for META (LIST/HEAD/DELETE/STAT), GET, and PUT operations
 - **Per-client statistics**: Compare performance across multiple clients with `--per-client` option
@@ -43,26 +44,29 @@ cargo build --release
 # Display help
 polarwarp-rs --help
 
-# Process a single file
-polarwarp-rs oplog.tsv.zst
+# Process a single trace file
+polarwarp-rs oplog.trace.tsv.zst
 
 # Process multiple files (results are consolidated)
-polarwarp-rs agent-1-oplog.tsv.zst agent-2-oplog.tsv.zst
+polarwarp-rs agent-1.trace.tsv.zst agent-2.trace.tsv.zst
+
+# Process a summary file (type is auto-detected)
+polarwarp-rs run.summary.tsv.zst
 
 # Skip first 2 minutes of warmup
-polarwarp-rs --skip 2m oplog.tsv.zst
+polarwarp-rs --skip 2m oplog.trace.tsv.zst
 
 # Compare performance across multiple clients
-polarwarp-rs --per-client multi_client_oplog.csv.zst
+polarwarp-rs --per-client multi_client_oplog.trace.tsv.zst
 
-# Export results to Excel
-polarwarp-rs --excel report.xlsx oplog.tsv.zst
+# Export results to Excel (summary files get their own tab)
+polarwarp-rs --excel report.xlsx oplog.trace.tsv.zst
 
 # Per-endpoint breakdown
-polarwarp-rs --per-endpoint oplog.tsv.zst
+polarwarp-rs --per-endpoint oplog.trace.tsv.zst
 
 # Show basic file info only
-polarwarp-rs --basic-stats oplog.tsv.zst
+polarwarp-rs --basic-stats oplog.trace.tsv.zst
 ```
 
 ### Command Line Options

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,6 +3,7 @@
 [![Version](https://img.shields.io/badge/version-0.1.7-blue.svg)](Cargo.toml)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
+[![Tests](https://img.shields.io/badge/tests-28%20passing-brightgreen.svg)](src/main.rs)
 
 A high-performance Rust implementation of PolarWarp for analyzing storage I/O operation logs.
 
@@ -147,6 +148,25 @@ idx  thread  op  client_id  n_objects  bytes  endpoint  file  error  start  firs
 - [Clap](https://clap.rs/) - Command-line argument parsing
 - [Chrono](https://docs.rs/chrono/) - Date/time handling
 - [zstd](https://docs.rs/zstd/) - Zstandard compression
+
+## Testing
+
+The Rust implementation has 28 unit tests embedded in `src/main.rs` (in the `#[cfg(test)] mod tests` block).
+
+```bash
+# Run all tests
+cargo test
+
+# Run tests with output visible
+cargo test -- --nocapture
+
+# Run a specific test by name
+cargo test test_size_bucket
+```
+
+Tests cover: `parse_skip_time`, `format_with_commas`, `format_int_with_commas`,
+`format_duration_ns`, `derive_short_name`, `derive_excel_path`, `make_tab_name`,
+`FileType` equality, and `add_size_buckets`.
 
 ## Related Projects
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # PolarWarp - Rust Implementation
 
-[![Version](https://img.shields.io/badge/version-0.1.7-blue.svg)](Cargo.toml)
+[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](Cargo.toml)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
 [![Tests](https://img.shields.io/badge/tests-28%20passing-brightgreen.svg)](src/main.rs)
@@ -60,8 +60,11 @@ polarwarp-rs --skip 2m oplog.trace.tsv.zst
 # Compare performance across multiple clients
 polarwarp-rs --per-client multi_client_oplog.trace.tsv.zst
 
-# Export results to Excel (summary files get their own tab)
+# Export results to Excel
 polarwarp-rs --excel report.xlsx oplog.trace.tsv.zst
+
+# Summary files produce a Stats tab + a Charts tab (ops/sec and MiB/s over time)
+polarwarp-rs --excel run.summary.tsv.zst
 
 # Per-endpoint breakdown
 polarwarp-rs --per-endpoint oplog.trace.tsv.zst
@@ -176,7 +179,6 @@ Tests cover: `parse_skip_time`, `format_with_commas`, `format_int_with_commas`,
 ## Future Enhancements
 
 - Parallel file processing with Rayon
-- Time-window analysis for detecting performance changes
 - Comparative analysis between test runs
 
 ## License

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -19,6 +19,15 @@ type ExcelTabRows = (Vec<Vec<String>>, Vec<Vec<String>>);
 /// Per-file Excel data collected before writing: (results_rows, detail_rows, file_path)
 type FileExcelEntry = (Vec<Vec<String>>, Vec<Vec<String>>, String);
 
+/// Detected format of an input file.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FileType {
+    /// Per-operation trace: columns include duration_ns, bytes, client_id, …
+    Trace,
+    /// Aggregated time-series summary: columns are op, start, end, bps, ops_per_sec, errors
+    Summary,
+}
+
 /// Number of size buckets (matching sai3-bench)
 const NUM_BUCKETS: usize = 9;
 
@@ -167,6 +176,56 @@ fn detect_separator(file_path: &str) -> Result<u8> {
     }
 }
 
+/// Read the first non-empty, non-comment header line from a (possibly zstd) file.
+fn read_header_line(file_path: &str) -> Result<String> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    let file = File::open(file_path)
+        .with_context(|| format!("Failed to open file: {}", file_path))?;
+
+    let read_first_non_comment = |reader: &mut dyn BufRead| -> Result<String> {
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line)? == 0 {
+                anyhow::bail!("File '{}' has no header row", file_path);
+            }
+            let trimmed = line.trim().to_string();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                return Ok(trimmed);
+            }
+        }
+    };
+
+    if file_path.ends_with(".zst") {
+        let decoder = zstd::stream::read::Decoder::new(file)
+            .with_context(|| format!("Failed to decompress zstd file: {}", file_path))?;
+        let mut reader = BufReader::new(decoder);
+        read_first_non_comment(&mut reader)
+    } else {
+        let mut reader = BufReader::new(file);
+        read_first_non_comment(&mut reader)
+    }
+}
+
+/// Detect whether a file is a per-op trace or an aggregated summary,
+/// by inspecting the header columns.
+fn detect_file_type(file_path: &str) -> Result<FileType> {
+    let header = read_header_line(file_path)?;
+    let cols: Vec<&str> = header.split('\t').collect();
+    if cols.contains(&"bps") && cols.contains(&"ops_per_sec") {
+        Ok(FileType::Summary)
+    } else if cols.contains(&"duration_ns") {
+        Ok(FileType::Trace)
+    } else {
+        anyhow::bail!(
+            "File '{}' has unrecognized header columns: {}\n\
+             Expected either trace columns (duration_ns, …) or summary columns (bps, ops_per_sec, …)",
+            file_path, header
+        )
+    }
+}
+
 /// Format a number with commas for readability
 fn format_with_commas(value: f64) -> String {
     if value.is_nan() || value.is_infinite() {
@@ -220,11 +279,38 @@ fn main() -> Result<()> {
     // Excel: per-file collected rows (main_rows, detail_rows, file_path)
     let mut file_excel_data: Vec<FileExcelEntry> = Vec::new();
 
+    // Summary-file Excel rows collected separately (one entry per file)
+    let mut summary_excel_data: Vec<(Vec<Vec<String>>, String)> = Vec::new();
+    let mut any_summary_file = false;
+    let mut any_trace_file = false;
+
     // Process each file
     for file_path in &args.files {
         println!("\nProcessing file: {}", file_path);
 
         let start = Instant::now();
+
+        // Detect file type and route to the appropriate handler
+        let file_type = detect_file_type(file_path)?;
+
+        match file_type {
+            FileType::Summary => {
+                any_summary_file = true;
+                println!("Summary Statistics for: {}", file_path);
+                let (df, _, _) = process_summary_file(file_path)?;
+                if excel_path.is_some() {
+                    let rows = collect_summary_excel_rows(&df)?;
+                    summary_excel_data.push((rows, file_path.clone()));
+                }
+                let elapsed = start.elapsed();
+                println!("Processed file in {:.2?}", elapsed);
+                // Do not push to all_dataframes — summary rows are not per-op trace rows
+                continue;
+            }
+            FileType::Trace => {
+                any_trace_file = true;
+            }
+        }
 
         // Read and process the file
         let (df, file_start_ns, file_end_ns) = process_file(
@@ -260,6 +346,14 @@ fn main() -> Result<()> {
 
         let elapsed = start.elapsed();
         println!("Processed file in {:.2?}", elapsed);
+    }
+
+    // Warn if the user mixed trace and summary files in one invocation
+    if any_trace_file && any_summary_file {
+        eprintln!(
+            "WARNING: Mixed trace and summary files provided.  \
+             Consolidation is skipped for summary files; each is reported independently."
+        );
     }
 
     // Excel: consolidated tab data (populated below if multiple files)
@@ -395,6 +489,13 @@ fn main() -> Result<()> {
             if !detail_rows.is_empty() {
                 tabs.push(("Consol-Detail".to_string(), detail_rows));
             }
+        }
+
+        // Add one tab per summary file
+        for (rows, fp) in &summary_excel_data {
+            let short = derive_short_name(fp);
+            let tab_name = make_tab_name(&short, "Summary");
+            tabs.push((tab_name, rows.clone()));
         }
 
         if !tabs.is_empty() {
@@ -1288,7 +1389,279 @@ fn print_basic_stats(df: &DataFrame) {
     println!("{}", sample);
 }
 
-// ─────────────────────────── Excel helpers ───────────────────────────────────
+// ─────────────────────────── Summary file support ───────────────────────────
+
+/// Read an aggregated summary file (.summary.tsv.zst) into a DataFrame.
+/// Validates required columns, parses start/end timestamps to start_ns/end_ns.
+fn read_summary_file(file_path: &str) -> Result<DataFrame> {
+    let path = Path::new(file_path);
+    if !path.exists() {
+        anyhow::bail!("File not found: {}", file_path);
+    }
+
+    let parse_options = CsvParseOptions::default()
+        .with_separator(b'\t')
+        .with_try_parse_dates(false)
+        .with_missing_is_null(true)
+        .with_comment_prefix::<&str>(Some("#"))
+        .with_truncate_ragged_lines(true);
+
+    let read_options = CsvReadOptions::default()
+        .with_parse_options(parse_options)
+        .with_ignore_errors(true)
+        .with_has_header(true);
+
+    let df = read_options
+        .try_into_reader_with_file_path(Some(path.to_path_buf()))?
+        .finish()
+        .with_context(|| format!("Failed to read summary file '{}'", file_path))?;
+
+    if df.height() == 0 {
+        anyhow::bail!("Summary file '{}' contains no data rows", file_path);
+    }
+
+    let required = ["op", "start", "end", "bps", "ops_per_sec", "errors"];
+    let cols: Vec<String> = df.get_column_names().iter().map(|s| s.to_string()).collect();
+    let missing: Vec<&str> = required.iter()
+        .filter(|c| !cols.contains(&c.to_string()))
+        .copied()
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "Summary file '{}' is missing required columns: {}",
+            file_path, missing.join(", ")
+        );
+    }
+
+    // Parse start/end to nanosecond timestamps for time-range computation
+    let df = df.lazy()
+        .with_columns([
+            col("start")
+                .str().replace(lit("Z$"), lit("+00:00"), false)
+                .str().to_datetime(
+                    Some(TimeUnit::Nanoseconds),
+                    None,
+                    StrptimeOptions {
+                        format: Some("%Y-%m-%dT%H:%M:%S%.f%z".into()),
+                        strict: false,
+                        exact: false,
+                        cache: true,
+                    },
+                    lit("raise"),
+                )
+                .dt().timestamp(TimeUnit::Nanoseconds)
+                .alias("start_ns"),
+            col("end")
+                .str().replace(lit("Z$"), lit("+00:00"), false)
+                .str().to_datetime(
+                    Some(TimeUnit::Nanoseconds),
+                    None,
+                    StrptimeOptions {
+                        format: Some("%Y-%m-%dT%H:%M:%S%.f%z".into()),
+                        strict: false,
+                        exact: false,
+                        cache: true,
+                    },
+                    lit("raise"),
+                )
+                .dt().timestamp(TimeUnit::Nanoseconds)
+                .alias("end_ns"),
+            // Ensure bps is f64 (may be read as i64 if all values are whole numbers)
+            col("bps").cast(DataType::Float64),
+            col("ops_per_sec").cast(DataType::Float64),
+        ])
+        .collect()?;
+
+    Ok(df)
+}
+
+/// Process a single summary file: read, display stats, return (df, start_ns, end_ns).
+fn process_summary_file(file_path: &str) -> Result<(DataFrame, i64, i64)> {
+    let df = read_summary_file(file_path)?;
+
+    // Derive time range from start_ns / end_ns columns
+    let start_ns = df.column("start_ns")?.i64()?.into_iter().flatten().next()
+        .context("Could not determine start time from summary file")?;
+    let end_ns = df.column("end_ns")?.i64()?.into_iter().flatten().last()
+        .context("Could not determine end time from summary file")?;
+
+    let seg_count = df.height();
+    let duration_secs = (end_ns - start_ns) as f64 / 1_000_000_000.0;
+    println!("Time range: {} seconds  ({} segments)", duration_secs as i64, seg_count);
+
+    compute_and_display_summary_stats(&df)?;
+
+    Ok((df, start_ns, end_ns))
+}
+
+/// Compute and display per-op throughput variability statistics from a summary DataFrame.
+/// Columns: op, bps, ops_per_sec, errors  (plus start_ns/end_ns)
+fn compute_and_display_summary_stats(df: &DataFrame) -> Result<()> {
+    let stats = df.clone().lazy()
+        .group_by([col("op")])
+        .agg([
+            col("bps").count().alias("segments"),
+            (col("bps").mean()     / lit(1_048_576.0)).alias("mean_MBps"),
+            (col("bps").median()   / lit(1_048_576.0)).alias("p50_MBps"),
+            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p90_MBps"),
+            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p99_MBps"),
+            (col("bps").min()      / lit(1_048_576.0)).alias("min_MBps"),
+            (col("bps").max()      / lit(1_048_576.0)).alias("max_MBps"),
+            (col("bps").std(1)     / lit(1_048_576.0)).alias("stdev_MBps"),
+            col("ops_per_sec").mean().alias("mean_ops"),
+            col("ops_per_sec").median().alias("p50_ops"),
+            col("ops_per_sec").quantile(lit(0.99), QuantileMethod::Linear).alias("p99_ops"),
+            col("errors").cast(DataType::Int64).sum().alias("total_errors"),
+        ])
+        // Sort: TOTAL last, everything else alphabetical
+        .sort(
+            ["op"],
+            SortMultipleOptions::default(),
+        )
+        .collect()?;
+
+    if stats.height() == 0 {
+        println!("  (no data)");
+        return Ok(());
+    }
+
+    println!(
+        "{:>8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>13}",
+        "op", "segs",
+        "mean_MBps", "p50_MBps", "p90_MBps", "p99_MBps",
+        "min_MBps", "max_MBps", "stdev_MBps",
+        "mean_ops/s", "p50_ops/s", "p99_ops/s",
+        "total_errors"
+    );
+
+    let op_col     = stats.column("op")?.str()?;
+    let segs_col   = stats.column("segments")?.u32()?;
+    let mean_col   = stats.column("mean_MBps")?.f64()?;
+    let p50_col    = stats.column("p50_MBps")?.f64()?;
+    let p90_col    = stats.column("p90_MBps")?.f64()?;
+    let p99_col    = stats.column("p99_MBps")?.f64()?;
+    let min_col    = stats.column("min_MBps")?.f64()?;
+    let max_col    = stats.column("max_MBps")?.f64()?;
+    let stdev_col  = stats.column("stdev_MBps")?.f64()?;
+    let mops_col   = stats.column("mean_ops")?.f64()?;
+    let p50ops_col = stats.column("p50_ops")?.f64()?;
+    let p99ops_col = stats.column("p99_ops")?.f64()?;
+    let errs_col   = stats.column("total_errors")?.i64()?;
+
+    // Print non-TOTAL rows first, then TOTAL
+    let height = stats.height();
+    let print_row = |i: usize| {
+        let op    = op_col.get(i).unwrap_or("?");
+        let segs  = segs_col.get(i).unwrap_or(0);
+        let mean  = mean_col.get(i).unwrap_or(0.0);
+        let p50   = p50_col.get(i).unwrap_or(0.0);
+        let p90   = p90_col.get(i).unwrap_or(0.0);
+        let p99   = p99_col.get(i).unwrap_or(0.0);
+        let min   = min_col.get(i).unwrap_or(0.0);
+        let max   = max_col.get(i).unwrap_or(0.0);
+        let std   = stdev_col.get(i).unwrap_or(0.0);
+        let mops  = mops_col.get(i).unwrap_or(0.0);
+        let p50op = p50ops_col.get(i).unwrap_or(0.0);
+        let p99op = p99ops_col.get(i).unwrap_or(0.0);
+        let errs  = errs_col.get(i).unwrap_or(0);
+        println!(
+            "{:>8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>13}",
+            op, segs,
+            format_with_commas(mean), format_with_commas(p50),
+            format_with_commas(p90),  format_with_commas(p99),
+            format_with_commas(min),  format_with_commas(max),
+            format_with_commas(std),
+            format_with_commas(mops), format_with_commas(p50op), format_with_commas(p99op),
+            format_int_with_commas(errs),
+        );
+    };
+
+    for i in 0..height {
+        if op_col.get(i).unwrap_or("") != "TOTAL" {
+            print_row(i);
+        }
+    }
+    // Print TOTAL row last
+    for i in 0..height {
+        if op_col.get(i).unwrap_or("") == "TOTAL" {
+            print_row(i);
+        }
+    }
+
+    Ok(())
+}
+
+/// Collect summary stats rows for Excel export (header + data rows, no commas in numbers).
+fn collect_summary_excel_rows(df: &DataFrame) -> Result<Vec<Vec<String>>> {
+    let stats = df.clone().lazy()
+        .group_by([col("op")])
+        .agg([
+            col("bps").count().alias("segments"),
+            (col("bps").mean()     / lit(1_048_576.0)).alias("mean_MBps"),
+            (col("bps").median()   / lit(1_048_576.0)).alias("p50_MBps"),
+            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p90_MBps"),
+            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p99_MBps"),
+            (col("bps").min()      / lit(1_048_576.0)).alias("min_MBps"),
+            (col("bps").max()      / lit(1_048_576.0)).alias("max_MBps"),
+            (col("bps").std(1)     / lit(1_048_576.0)).alias("stdev_MBps"),
+            col("ops_per_sec").mean().alias("mean_ops"),
+            col("ops_per_sec").median().alias("p50_ops"),
+            col("ops_per_sec").quantile(lit(0.99), QuantileMethod::Linear).alias("p99_ops"),
+            col("errors").cast(DataType::Int64).sum().alias("total_errors"),
+        ])
+        .sort(["op"], SortMultipleOptions::default())
+        .collect()?;
+
+    let mut rows: Vec<Vec<String>> = vec![vec![
+        "op".into(), "segments".into(),
+        "mean_MBps".into(), "p50_MBps".into(), "p90_MBps".into(), "p99_MBps".into(),
+        "min_MBps".into(), "max_MBps".into(), "stdev_MBps".into(),
+        "mean_ops/s".into(), "p50_ops/s".into(), "p99_ops/s".into(),
+        "total_errors".into(),
+    ]];
+
+    let op_col     = stats.column("op")?.str()?;
+    let segs_col   = stats.column("segments")?.u32()?;
+    let mean_col   = stats.column("mean_MBps")?.f64()?;
+    let p50_col    = stats.column("p50_MBps")?.f64()?;
+    let p90_col    = stats.column("p90_MBps")?.f64()?;
+    let p99_col    = stats.column("p99_MBps")?.f64()?;
+    let min_col    = stats.column("min_MBps")?.f64()?;
+    let max_col    = stats.column("max_MBps")?.f64()?;
+    let stdev_col  = stats.column("stdev_MBps")?.f64()?;
+    let mops_col   = stats.column("mean_ops")?.f64()?;
+    let p50ops_col = stats.column("p50_ops")?.f64()?;
+    let p99ops_col = stats.column("p99_ops")?.f64()?;
+    let errs_col   = stats.column("total_errors")?.i64()?;
+
+    // Non-TOTAL rows first, then TOTAL
+    let height = stats.height();
+    let push_row = |rows: &mut Vec<Vec<String>>, i: usize| {
+        rows.push(vec![
+            op_col.get(i).unwrap_or("?").to_string(),
+            segs_col.get(i).unwrap_or(0).to_string(),
+            format!("{:.2}", mean_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", p50_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", p90_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", p99_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", min_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", max_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", stdev_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", mops_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", p50ops_col.get(i).unwrap_or(0.0)),
+            format!("{:.2}", p99ops_col.get(i).unwrap_or(0.0)),
+            errs_col.get(i).unwrap_or(0).to_string(),
+        ]);
+    };
+    for i in 0..height {
+        if op_col.get(i).unwrap_or("") != "TOTAL" { push_row(&mut rows, i); }
+    }
+    for i in 0..height {
+        if op_col.get(i).unwrap_or("") == "TOTAL" { push_row(&mut rows, i); }
+    }
+
+    Ok(rows)
+}
 
 /// Derive a short display name from a file path for use as an Excel tab prefix.
 /// Strips path, extensions (.zst, .csv, .tsv), and warp timestamp brackets.

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use clap::{Parser, ArgAction};
+use clap::{ArgAction, Parser};
 use num_format::{Locale, ToFormattedString};
 use polars::prelude::*;
 use regex::Regex;
@@ -32,12 +32,12 @@ enum FileType {
 const NUM_BUCKETS: usize = 9;
 
 /// Size bucket boundaries (in bytes) - matching sai3-bench
-const BUCKET_8K: i64 = 8 * 1024;              // 8 KiB
-const BUCKET_64K: i64 = 64 * 1024;            // 64 KiB  
-const BUCKET_512K: i64 = 512 * 1024;          // 512 KiB
-const BUCKET_4M: i64 = 4 * 1024 * 1024;       // 4 MiB
-const BUCKET_32M: i64 = 32 * 1024 * 1024;     // 32 MiB
-const BUCKET_256M: i64 = 256 * 1024 * 1024;   // 256 MiB
+const BUCKET_8K: i64 = 8 * 1024; // 8 KiB
+const BUCKET_64K: i64 = 64 * 1024; // 64 KiB
+const BUCKET_512K: i64 = 512 * 1024; // 512 KiB
+const BUCKET_4M: i64 = 4 * 1024 * 1024; // 4 MiB
+const BUCKET_32M: i64 = 32 * 1024 * 1024; // 32 MiB
+const BUCKET_256M: i64 = 256 * 1024 * 1024; // 256 MiB
 const BUCKET_2G: i64 = 2 * 1024 * 1024 * 1024; // 2 GiB
 
 /// Size bucket labels (matching sai3-bench)
@@ -107,20 +107,23 @@ struct Args {
 /// Parse skip time argument (e.g., "90s" or "5m") into nanoseconds
 fn parse_skip_time(skip: &str) -> Result<i64> {
     let re = Regex::new(r"^(\d+)([sm])$")?;
-    
+
     if let Some(caps) = re.captures(skip) {
         let value: i64 = caps.get(1).unwrap().as_str().parse()?;
         let unit = caps.get(2).unwrap().as_str();
-        
+
         let nanos = match unit {
             "s" => value * 1_000_000_000,
             "m" => value * 60 * 1_000_000_000,
             _ => anyhow::bail!("Invalid time unit: {}", unit),
         };
-        
+
         Ok(nanos)
     } else {
-        anyhow::bail!("Invalid skip format '{}'. Use format like '90s' or '5m'", skip)
+        anyhow::bail!(
+            "Invalid skip format '{}'. Use format like '90s' or '5m'",
+            skip
+        )
     }
 }
 
@@ -129,40 +132,44 @@ fn parse_skip_time(skip: &str) -> Result<i64> {
 fn detect_separator(file_path: &str) -> Result<u8> {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
-    
-    let file = File::open(file_path)
-        .with_context(|| format!("Failed to open file: {}", file_path))?;
-    
+
+    let file =
+        File::open(file_path).with_context(|| format!("Failed to open file: {}", file_path))?;
+
     // Handle zstd compressed files
     let first_line = if file_path.ends_with(".zst") {
         let decoder = zstd::stream::read::Decoder::new(file)
             .with_context(|| format!("Failed to decompress zstd file: {}", file_path))?;
         let mut reader = BufReader::new(decoder);
         let mut line = String::new();
-        reader.read_line(&mut line)
-            .with_context(|| format!("Failed to read header from compressed file: {}", file_path))?;
+        reader.read_line(&mut line).with_context(|| {
+            format!("Failed to read header from compressed file: {}", file_path)
+        })?;
         line
     } else {
         let mut reader = BufReader::new(file);
         let mut line = String::new();
-        reader.read_line(&mut line)
+        reader
+            .read_line(&mut line)
             .with_context(|| format!("Failed to read header from file: {}", file_path))?;
         line
     };
-    
+
     if first_line.is_empty() {
         anyhow::bail!("File '{}' is empty or has no header", file_path);
     }
-    
+
     // Count tabs vs commas in header line
     let tab_count = first_line.matches('\t').count();
     let comma_count = first_line.matches(',').count();
-    
+
     // Use whichever delimiter appears more often
     // Note: warp program creates .csv files that are actually tab-separated!
     if tab_count > comma_count {
         if file_path.contains(".csv") && tab_count > 0 {
-            eprintln!("Note: File has .csv extension but uses tab separation (typical for warp output)");
+            eprintln!(
+                "Note: File has .csv extension but uses tab separation (typical for warp output)"
+            );
         }
         Ok(b'\t')
     } else if comma_count > 0 {
@@ -170,9 +177,12 @@ fn detect_separator(file_path: &str) -> Result<u8> {
     } else {
         // No clear delimiter found, might be invalid format
         if tab_count == 0 && comma_count == 0 {
-            eprintln!("Warning: No delimiter found in file '{}', defaulting to tab", file_path);
+            eprintln!(
+                "Warning: No delimiter found in file '{}', defaulting to tab",
+                file_path
+            );
         }
-        Ok(b'\t')  // Default to tab
+        Ok(b'\t') // Default to tab
     }
 }
 
@@ -181,8 +191,8 @@ fn read_header_line(file_path: &str) -> Result<String> {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
 
-    let file = File::open(file_path)
-        .with_context(|| format!("Failed to open file: {}", file_path))?;
+    let file =
+        File::open(file_path).with_context(|| format!("Failed to open file: {}", file_path))?;
 
     let read_first_non_comment = |reader: &mut dyn BufRead| -> Result<String> {
         loop {
@@ -231,11 +241,15 @@ fn format_with_commas(value: f64) -> String {
     if value.is_nan() || value.is_infinite() {
         return format!("{:.2}", value);
     }
-    
+
     let int_part = value.trunc() as i64;
     let frac_part = (value.fract() * 100.0).round() as i64;
-    
-    format!("{}.{:02}", int_part.to_formatted_string(&Locale::en), frac_part.abs())
+
+    format!(
+        "{}.{:02}",
+        int_part.to_formatted_string(&Locale::en),
+        frac_part.abs()
+    )
 }
 
 /// Format integer with commas
@@ -269,10 +283,10 @@ fn main() -> Result<()> {
     let mut all_dataframes: Vec<DataFrame> = Vec::new();
     // Overlap window: latest start / earliest end across all files
     let mut overlap_start_ns: Option<i64> = None;
-    let mut overlap_end_ns:   Option<i64> = None;
+    let mut overlap_end_ns: Option<i64> = None;
     // Union window: earliest start / latest end across all files
     let mut union_start_ns: Option<i64> = None;
-    let mut union_end_ns:   Option<i64> = None;
+    let mut union_end_ns: Option<i64> = None;
     // Per-file time ranges for diagnostic output
     let mut file_ranges: Vec<(String, i64, i64)> = Vec::new();
 
@@ -315,7 +329,7 @@ fn main() -> Result<()> {
 
         // Read and process the file
         let (df, file_start_ns, file_end_ns) = process_file(
-            file_path, 
+            file_path,
             skip_nanos,
             args.basic_stats,
             args.per_client,
@@ -325,9 +339,9 @@ fn main() -> Result<()> {
         // Update overlap (latest-start / earliest-end) and union (earliest-start / latest-end)
         if let (Some(fs), Some(fe)) = (file_start_ns, file_end_ns) {
             overlap_start_ns = Some(overlap_start_ns.map_or(fs, |v: i64| v.max(fs)));
-            overlap_end_ns   = Some(overlap_end_ns  .map_or(fe, |v: i64| v.min(fe)));
-            union_start_ns   = Some(union_start_ns  .map_or(fs, |v: i64| v.min(fs)));
-            union_end_ns     = Some(union_end_ns    .map_or(fe, |v: i64| v.max(fe)));
+            overlap_end_ns = Some(overlap_end_ns.map_or(fe, |v: i64| v.min(fe)));
+            union_start_ns = Some(union_start_ns.map_or(fs, |v: i64| v.min(fs)));
+            union_end_ns = Some(union_end_ns.map_or(fe, |v: i64| v.max(fe)));
             file_ranges.push((file_path.clone(), fs, fe));
         }
 
@@ -366,14 +380,22 @@ fn main() -> Result<()> {
 
         // Print per-file time ranges for transparency
         for (fp, fs, fe) in &file_ranges {
-            println!("  File time range: {}  (duration: {})",
-                     fp, format_duration_ns(fe - fs));
+            println!(
+                "  File time range: {}  (duration: {})",
+                fp,
+                format_duration_ns(fe - fs)
+            );
         }
 
-        match (overlap_start_ns, overlap_end_ns, union_start_ns, union_end_ns) {
+        match (
+            overlap_start_ns,
+            overlap_end_ns,
+            union_start_ns,
+            union_end_ns,
+        ) {
             (Some(os), Some(oe), Some(us), Some(ue)) => {
-                let overlap_dur = oe - os;   // may be ≤ 0 if no intersection
-                let union_dur   = ue - us;
+                let overlap_dur = oe - os; // may be ≤ 0 if no intersection
+                let union_dur = ue - us;
 
                 // Jaccard in [0, 1]; clamp to 0 if no intersection
                 let jaccard_pct = if overlap_dur <= 0 || union_dur <= 0 {
@@ -382,7 +404,11 @@ fn main() -> Result<()> {
                     (overlap_dur as f64 / union_dur as f64) * 100.0
                 };
 
-                println!("  Overlap window: {} ns  Union window: {} ns", overlap_dur.max(0), union_dur);
+                println!(
+                    "  Overlap window: {} ns  Union window: {} ns",
+                    overlap_dur.max(0),
+                    union_dur
+                );
                 println!("  Jaccard overlap: {:.1}%  (overlap / union)", jaccard_pct);
 
                 if jaccard_pct < OVERLAP_MIN_PCT {
@@ -408,8 +434,11 @@ fn main() -> Result<()> {
                     }
 
                     let overlap_secs = overlap_dur as f64 / 1_000_000_000.0;
-                    println!("  Overlap duration: {}  ({:.2} s)",
-                             format_duration_ns(overlap_dur), overlap_secs);
+                    println!(
+                        "  Overlap duration: {}  ({:.2} s)",
+                        format_duration_ns(overlap_dur),
+                        overlap_secs
+                    );
 
                     // Filter each dataframe to operations whose start falls within
                     // [overlap_start, overlap_end) then concatenate
@@ -422,14 +451,21 @@ fn main() -> Result<()> {
 
                     // Compute and display consolidated stats
                     compute_and_display_stats(
-                        &consolidated_df, overlap_secs,
-                        "Consolidated Results:", args.per_client, args.per_endpoint,
+                        &consolidated_df,
+                        overlap_secs,
+                        "Consolidated Results:",
+                        args.per_client,
+                        args.per_endpoint,
                     )?;
 
                     // Collect consolidated Excel rows if requested
                     if excel_path.is_some() {
-                        let (main_rows, detail_rows) =
-                            collect_stats_rows(&consolidated_df, overlap_secs, args.per_client, args.per_endpoint)?;
+                        let (main_rows, detail_rows) = collect_stats_rows(
+                            &consolidated_df,
+                            overlap_secs,
+                            args.per_client,
+                            args.per_endpoint,
+                        )?;
                         consolidated_excel = Some((main_rows, detail_rows));
                     }
                 }
@@ -450,26 +486,31 @@ fn main() -> Result<()> {
         let short_names: Vec<String> = if single {
             vec!["".to_string()]
         } else {
-            let raw: Vec<String> = file_excel_data.iter()
+            let raw: Vec<String> = file_excel_data
+                .iter()
                 .map(|(_, _, fp)| derive_short_name(fp))
                 .collect();
             // Count how many times each derived name appears.
             let mut tally: std::collections::HashMap<String, usize> =
                 std::collections::HashMap::new();
-            for n in &raw { *tally.entry(n.clone()).or_insert(0) += 1; }
+            for n in &raw {
+                *tally.entry(n.clone()).or_insert(0) += 1;
+            }
             // For duplicates, append a 1-based counter suffix (-1, -2, …).
             let mut seen: std::collections::HashMap<String, usize> =
                 std::collections::HashMap::new();
-            raw.iter().map(|n| {
-                if tally[n] > 1 {
-                    let counter = seen.entry(n.clone()).or_insert(1);
-                    let unique = format!("{}-{}", n, counter);
-                    *counter += 1;
-                    unique
-                } else {
-                    n.clone()
-                }
-            }).collect()
+            raw.iter()
+                .map(|n| {
+                    if tally[n] > 1 {
+                        let counter = seen.entry(n.clone()).or_insert(1);
+                        let unique = format!("{}-{}", n, counter);
+                        *counter += 1;
+                        unique
+                    } else {
+                        n.clone()
+                    }
+                })
+                .collect()
         };
 
         for (i, (main_rows, detail_rows, _fp)) in file_excel_data.iter().enumerate() {
@@ -477,7 +518,10 @@ fn main() -> Result<()> {
                 ("Results".to_string(), "Detail".to_string())
             } else {
                 let short = &short_names[i];
-                (make_tab_name(short, "Results"), make_tab_name(short, "Detail"))
+                (
+                    make_tab_name(short, "Results"),
+                    make_tab_name(short, "Detail"),
+                )
             };
             tabs.push((results_tab, main_rows.clone()));
             if !detail_rows.is_empty() {
@@ -515,25 +559,26 @@ fn concat_dataframes(dfs: &[DataFrame]) -> Result<DataFrame> {
     if dfs.is_empty() {
         anyhow::bail!("No dataframes to concatenate");
     }
-    
+
     if dfs.len() == 1 {
         return Ok(dfs[0].clone());
     }
-    
+
     let lazy_frames: Vec<LazyFrame> = dfs.iter().map(|df| df.clone().lazy()).collect();
-    let result = concat(lazy_frames, UnionArgs::default())?
-        .collect()?;
-    
+    let result = concat(lazy_frames, UnionArgs::default())?.collect()?;
+
     Ok(result)
 }
 
 /// Filter a dataframe to rows whose `start_ns` falls within [window_start, window_end).
 /// Used to restrict each file's data to the shared overlap window before consolidating.
 fn filter_to_window(df: DataFrame, window_start: i64, window_end: i64) -> Result<DataFrame> {
-    let filtered = df.lazy()
+    let filtered = df
+        .lazy()
         .filter(
-            col("start_ns").gt_eq(lit(window_start))
-            .and(col("start_ns").lt(lit(window_end)))
+            col("start_ns")
+                .gt_eq(lit(window_start))
+                .and(col("start_ns").lt(lit(window_end))),
         )
         .collect()?;
     Ok(filtered)
@@ -545,13 +590,13 @@ fn format_duration_ns(nanos: i64) -> String {
     let hours = (total_secs / 3600.0).floor() as i64;
     let minutes = ((total_secs % 3600.0) / 60.0).floor() as i64;
     let secs = total_secs % 60.0;
-    
+
     format!("{}:{:02}:{:09.6}", hours, minutes, secs)
 }
 
 /// Process a single file and return the dataframe with computed metrics
 fn process_file(
-    file_path: &str, 
+    file_path: &str,
     skip_nanos: Option<i64>,
     basic_stats_only: bool,
     per_client: bool,
@@ -573,17 +618,18 @@ fn process_file(
 
     // Get start and end times (in nanoseconds since epoch)
     let (start_ns, end_ns) = get_time_range(&df)?;
-    
+
     // Apply skip time if specified
     let effective_start_ns = if let Some(skip) = skip_nanos {
         let new_start = start_ns + skip;
         println!("Skipping rows with 'start' <= {} ns", new_start);
-        
+
         // Filter out rows before skip threshold
-        df = df.lazy()
+        df = df
+            .lazy()
             .filter(col("start_ns").gt(lit(new_start)))
             .collect()?;
-        
+
         new_start
     } else {
         start_ns
@@ -591,7 +637,10 @@ fn process_file(
 
     let run_time_secs = (end_ns - effective_start_ns) as f64 / 1_000_000_000.0;
     let run_time_formatted = format_duration_ns(end_ns - effective_start_ns);
-    println!("The file run time is {}, time in seconds is: {:.2}", run_time_formatted, run_time_secs);
+    println!(
+        "The file run time is {}, time in seconds is: {:.2}",
+        run_time_formatted, run_time_secs
+    );
 
     // Add size buckets
     df = add_size_buckets(df)?;
@@ -605,16 +654,16 @@ fn process_file(
 /// Read a TSV or CSV file (optionally zstd compressed) into a DataFrame
 fn read_tsv_file(file_path: &str) -> Result<DataFrame> {
     let path = Path::new(file_path);
-    
+
     // Check if file exists
     if !path.exists() {
         anyhow::bail!("File not found: {}", file_path);
     }
-    
+
     if !path.is_file() {
         anyhow::bail!("Not a file: {}", file_path);
     }
-    
+
     // Detect separator by reading first line of the file
     let separator = detect_separator(file_path)
         .with_context(|| format!("Failed to detect separator in file: {}", file_path))?;
@@ -633,25 +682,32 @@ fn read_tsv_file(file_path: &str) -> Result<DataFrame> {
     let df = read_options
         .try_into_reader_with_file_path(Some(path.to_path_buf()))?
         .finish()
-        .with_context(|| format!("Failed to read file '{}'. Ensure it's a valid CSV/TSV file", file_path))?;
+        .with_context(|| {
+            format!(
+                "Failed to read file '{}'. Ensure it's a valid CSV/TSV file",
+                file_path
+            )
+        })?;
 
     // Validate the dataframe has data
     if df.height() == 0 {
         anyhow::bail!("File '{}' contains no data rows", file_path);
     }
-    
+
     // Validate required columns exist
     let required_columns = ["start", "end", "op", "bytes", "duration_ns"];
-    let column_names: Vec<String> = df.get_column_names()
+    let column_names: Vec<String> = df
+        .get_column_names()
         .iter()
         .map(|s| s.to_string())
         .collect();
-    
-    let missing: Vec<&str> = required_columns.iter()
+
+    let missing: Vec<&str> = required_columns
+        .iter()
         .filter(|col| !column_names.contains(&col.to_string()))
         .copied()
         .collect();
-    
+
     if !missing.is_empty() {
         anyhow::bail!(
             "File '{}' is missing required columns: {}",
@@ -667,7 +723,7 @@ fn read_tsv_file(file_path: &str) -> Result<DataFrame> {
 fn parse_timestamps(df: DataFrame) -> Result<DataFrame> {
     // Convert timestamp strings to nanoseconds since epoch
     // The timestamps are in format: 2025-12-02T23:16:43.054463723Z
-    
+
     let result = df.lazy()
         .with_columns([
             // Parse start timestamp - replace Z with +00:00 for proper parsing
@@ -716,7 +772,7 @@ fn parse_timestamps(df: DataFrame) -> Result<DataFrame> {
 fn get_time_range(df: &DataFrame) -> Result<(i64, i64)> {
     let start_col = df.column("start_ns")?;
     let end_col = df.column("end_ns")?;
-    
+
     // Get first non-null start time
     let start_ns = start_col
         .i64()?
@@ -724,7 +780,7 @@ fn get_time_range(df: &DataFrame) -> Result<(i64, i64)> {
         .flatten()
         .next()
         .context("Could not determine start time")?;
-    
+
     // Get last non-null end time
     let end_ns = end_col
         .i64()?
@@ -732,51 +788,108 @@ fn get_time_range(df: &DataFrame) -> Result<(i64, i64)> {
         .flatten()
         .last()
         .context("Could not determine end time")?;
-    
+
     Ok((start_ns, end_ns))
 }
 
 /// Add size bucket columns to the dataframe
 fn add_size_buckets(df: DataFrame) -> Result<DataFrame> {
-    let result = df.lazy()
+    let result = df
+        .lazy()
         .with_columns([
             // Create bucket label (matching sai3-bench bucket boundaries)
             when(col("bytes").eq(lit(0)))
-                .then(lit(BUCKET_LABELS[0]))  // zero
-            .when(col("bytes").gt_eq(lit(1)).and(col("bytes").lt(lit(BUCKET_8K))))
-                .then(lit(BUCKET_LABELS[1]))  // 1B-8KiB
-            .when(col("bytes").gt_eq(lit(BUCKET_8K)).and(col("bytes").lt(lit(BUCKET_64K))))
-                .then(lit(BUCKET_LABELS[2]))  // 8KiB-64KiB
-            .when(col("bytes").gt_eq(lit(BUCKET_64K)).and(col("bytes").lt(lit(BUCKET_512K))))
-                .then(lit(BUCKET_LABELS[3]))  // 64KiB-512KiB
-            .when(col("bytes").gt_eq(lit(BUCKET_512K)).and(col("bytes").lt(lit(BUCKET_4M))))
-                .then(lit(BUCKET_LABELS[4]))  // 512KiB-4MiB
-            .when(col("bytes").gt_eq(lit(BUCKET_4M)).and(col("bytes").lt(lit(BUCKET_32M))))
-                .then(lit(BUCKET_LABELS[5]))  // 4MiB-32MiB
-            .when(col("bytes").gt_eq(lit(BUCKET_32M)).and(col("bytes").lt(lit(BUCKET_256M))))
-                .then(lit(BUCKET_LABELS[6]))  // 32MiB-256MiB
-            .when(col("bytes").gt_eq(lit(BUCKET_256M)).and(col("bytes").lt(lit(BUCKET_2G))))
-                .then(lit(BUCKET_LABELS[7]))  // 256MiB-2GiB
-            .otherwise(lit(BUCKET_LABELS[8])) // >2GiB
+                .then(lit(BUCKET_LABELS[0])) // zero
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(1))
+                        .and(col("bytes").lt(lit(BUCKET_8K))),
+                )
+                .then(lit(BUCKET_LABELS[1])) // 1B-8KiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_8K))
+                        .and(col("bytes").lt(lit(BUCKET_64K))),
+                )
+                .then(lit(BUCKET_LABELS[2])) // 8KiB-64KiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_64K))
+                        .and(col("bytes").lt(lit(BUCKET_512K))),
+                )
+                .then(lit(BUCKET_LABELS[3])) // 64KiB-512KiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_512K))
+                        .and(col("bytes").lt(lit(BUCKET_4M))),
+                )
+                .then(lit(BUCKET_LABELS[4])) // 512KiB-4MiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_4M))
+                        .and(col("bytes").lt(lit(BUCKET_32M))),
+                )
+                .then(lit(BUCKET_LABELS[5])) // 4MiB-32MiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_32M))
+                        .and(col("bytes").lt(lit(BUCKET_256M))),
+                )
+                .then(lit(BUCKET_LABELS[6])) // 32MiB-256MiB
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_256M))
+                        .and(col("bytes").lt(lit(BUCKET_2G))),
+                )
+                .then(lit(BUCKET_LABELS[7])) // 256MiB-2GiB
+                .otherwise(lit(BUCKET_LABELS[8])) // >2GiB
                 .alias("bytes_bucket"),
             // Create bucket number for sorting
             when(col("bytes").eq(lit(0)))
                 .then(lit(0i32))
-            .when(col("bytes").gt_eq(lit(1)).and(col("bytes").lt(lit(BUCKET_8K))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(1))
+                        .and(col("bytes").lt(lit(BUCKET_8K))),
+                )
                 .then(lit(1i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_8K)).and(col("bytes").lt(lit(BUCKET_64K))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_8K))
+                        .and(col("bytes").lt(lit(BUCKET_64K))),
+                )
                 .then(lit(2i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_64K)).and(col("bytes").lt(lit(BUCKET_512K))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_64K))
+                        .and(col("bytes").lt(lit(BUCKET_512K))),
+                )
                 .then(lit(3i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_512K)).and(col("bytes").lt(lit(BUCKET_4M))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_512K))
+                        .and(col("bytes").lt(lit(BUCKET_4M))),
+                )
                 .then(lit(4i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_4M)).and(col("bytes").lt(lit(BUCKET_32M))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_4M))
+                        .and(col("bytes").lt(lit(BUCKET_32M))),
+                )
                 .then(lit(5i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_32M)).and(col("bytes").lt(lit(BUCKET_256M))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_32M))
+                        .and(col("bytes").lt(lit(BUCKET_256M))),
+                )
                 .then(lit(6i32))
-            .when(col("bytes").gt_eq(lit(BUCKET_256M)).and(col("bytes").lt(lit(BUCKET_2G))))
+                .when(
+                    col("bytes")
+                        .gt_eq(lit(BUCKET_256M))
+                        .and(col("bytes").lt(lit(BUCKET_2G))),
+                )
                 .then(lit(7i32))
-            .otherwise(lit(8i32))
+                .otherwise(lit(8i32))
                 .alias("bucket_num"),
         ])
         .collect()?;
@@ -794,7 +907,9 @@ fn compute_op_run_time(df: &DataFrame, ops: &[&str]) -> Result<f64> {
         filter_expr = filter_expr.or(col("op").eq(lit(*op)));
     }
 
-    let filtered = df.clone().lazy()
+    let filtered = df
+        .clone()
+        .lazy()
         .filter(filter_expr)
         .select([
             col("start_ns").min().alias("min_start"),
@@ -807,7 +922,7 @@ fn compute_op_run_time(df: &DataFrame, ops: &[&str]) -> Result<f64> {
     }
 
     let min_start = filtered.column("min_start")?.i64()?.get(0);
-    let max_end   = filtered.column("max_end")?.i64()?.get(0);
+    let max_end = filtered.column("max_end")?.i64()?.get(0);
 
     match (min_start, max_end) {
         (Some(s), Some(e)) if e > s => Ok((e - s) as f64 / 1_000_000_000.0),
@@ -816,20 +931,35 @@ fn compute_op_run_time(df: &DataFrame, ops: &[&str]) -> Result<f64> {
 }
 
 /// Compute and display performance statistics
-fn compute_and_display_stats(df: &DataFrame, run_time_secs: f64, title: &str, per_client: bool, per_endpoint: bool) -> Result<()> {
+fn compute_and_display_stats(
+    df: &DataFrame,
+    run_time_secs: f64,
+    title: &str,
+    per_client: bool,
+    per_endpoint: bool,
+) -> Result<()> {
     // Pre-compute per-operation time ranges to correctly handle non-overlapping workloads
     // (e.g., when PUT and GET phases run sequentially, not concurrently - issue #14)
     let meta_time = compute_op_run_time(df, &META_OPS).unwrap_or(run_time_secs);
-    let get_time  = compute_op_run_time(df, &["GET"]).unwrap_or(run_time_secs);
-    let put_time  = compute_op_run_time(df, &["PUT"]).unwrap_or(run_time_secs);
+    let get_time = compute_op_run_time(df, &["GET"]).unwrap_or(run_time_secs);
+    let put_time = compute_op_run_time(df, &["PUT"]).unwrap_or(run_time_secs);
 
     // Map op name to its effective run time (fall back to global if zero)
     let op_eff_time = |op: &str| -> f64 {
-        let t = if META_OPS.contains(&op) { meta_time }
-                else if op == "GET"       { get_time }
-                else if op == "PUT"       { put_time }
-                else                      { run_time_secs };
-        if t > 0.0 { t } else { run_time_secs }
+        let t = if META_OPS.contains(&op) {
+            meta_time
+        } else if op == "GET" {
+            get_time
+        } else if op == "PUT" {
+            put_time
+        } else {
+            run_time_secs
+        };
+        if t > 0.0 {
+            t
+        } else {
+            run_time_secs
+        }
     };
 
     // Check if thread column exists for concurrency reporting (issue #16)
@@ -840,27 +970,32 @@ fn compute_and_display_stats(df: &DataFrame, run_time_secs: f64, title: &str, pe
         // Latency statistics (convert ns to µs)
         (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
         (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-        (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90_lat_us"),
-        (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95_lat_us"),
-        (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
+        (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p90_lat_us"),
+        (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p95_lat_us"),
+        (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p99_lat_us"),
         (col("duration_ns").max() / lit(1000.0)).alias("max_lat_us"),
         // Size statistics
         (col("bytes").mean() / lit(1024.0)).alias("avg_obj_KB"),
         // Raw count and bytes_sum — rates computed per-row using per-op time
         col("op").count().alias("count"),
-        col("bytes").sum().cast(DataType::Float64).alias("bytes_sum"),
+        col("bytes")
+            .sum()
+            .cast(DataType::Float64)
+            .alias("bytes_sum"),
     ];
     if has_thread {
         agg_exprs.push(col("thread").n_unique().alias("max_threads"));
     }
 
-    let stats = df.clone().lazy()
+    let stats = df
+        .clone()
+        .lazy()
         .group_by([col("op"), col("bytes_bucket"), col("bucket_num")])
         .agg(agg_exprs)
-        .sort(
-            ["bucket_num", "op"],
-            SortMultipleOptions::default(),
-        )
+        .sort(["bucket_num", "op"], SortMultipleOptions::default())
         .collect()?;
 
     // Print the results
@@ -875,34 +1010,40 @@ fn compute_and_display_stats(df: &DataFrame, run_time_secs: f64, title: &str, pe
              "95%_lat_us", "99%_lat_us", "max_lat_us", "avg_obj_KB", "ops_/_sec", "xput_MBps", "count", "max_threads", "runtime_s");
 
     // Extract columns
-    let op_col         = stats.column("op")?.str()?;
-    let bucket_col     = stats.column("bytes_bucket")?.str()?;
+    let op_col = stats.column("op")?.str()?;
+    let bucket_col = stats.column("bytes_bucket")?.str()?;
     let bucket_num_col = stats.column("bucket_num")?.i32()?;
-    let mean_lat       = stats.column("mean_lat_us")?.f64()?;
-    let med_lat        = stats.column("med_lat_us")?.f64()?;
-    let p90_lat        = stats.column("p90_lat_us")?.f64()?;
-    let p95_lat        = stats.column("p95_lat_us")?.f64()?;
-    let p99_lat        = stats.column("p99_lat_us")?.f64()?;
-    let max_lat        = stats.column("max_lat_us")?.f64()?;
-    let avg_kb         = stats.column("avg_obj_KB")?.f64()?;
-    let count_col      = stats.column("count")?.u32()?;
-    let bytes_sum_col  = stats.column("bytes_sum")?.f64()?;
-    let concurrency_col = if has_thread { Some(stats.column("max_threads")?.u32()?) } else { None };
+    let mean_lat = stats.column("mean_lat_us")?.f64()?;
+    let med_lat = stats.column("med_lat_us")?.f64()?;
+    let p90_lat = stats.column("p90_lat_us")?.f64()?;
+    let p95_lat = stats.column("p95_lat_us")?.f64()?;
+    let p99_lat = stats.column("p99_lat_us")?.f64()?;
+    let max_lat = stats.column("max_lat_us")?.f64()?;
+    let avg_kb = stats.column("avg_obj_KB")?.f64()?;
+    let count_col = stats.column("count")?.u32()?;
+    let bytes_sum_col = stats.column("bytes_sum")?.f64()?;
+    let concurrency_col = if has_thread {
+        Some(stats.column("max_threads")?.u32()?)
+    } else {
+        None
+    };
 
     for i in 0..stats.height() {
-        let op         = op_col.get(i).unwrap_or("?");
-        let bucket     = bucket_col.get(i).unwrap_or("?");
+        let op = op_col.get(i).unwrap_or("?");
+        let bucket = bucket_col.get(i).unwrap_or("?");
         let bucket_num = bucket_num_col.get(i).unwrap_or(0);
-        let mean       = mean_lat.get(i).unwrap_or(0.0);
-        let med        = med_lat.get(i).unwrap_or(0.0);
-        let p90        = p90_lat.get(i).unwrap_or(0.0);
-        let p95        = p95_lat.get(i).unwrap_or(0.0);
-        let p99        = p99_lat.get(i).unwrap_or(0.0);
-        let max        = max_lat.get(i).unwrap_or(0.0);
-        let avg        = avg_kb.get(i).unwrap_or(0.0);
-        let cnt        = count_col.get(i).unwrap_or(0);
-        let bsum       = bytes_sum_col.get(i).unwrap_or(0.0);
-        let conc       = concurrency_col.as_ref().map_or(0, |c| c.get(i).unwrap_or(0));
+        let mean = mean_lat.get(i).unwrap_or(0.0);
+        let med = med_lat.get(i).unwrap_or(0.0);
+        let p90 = p90_lat.get(i).unwrap_or(0.0);
+        let p95 = p95_lat.get(i).unwrap_or(0.0);
+        let p99 = p99_lat.get(i).unwrap_or(0.0);
+        let max = max_lat.get(i).unwrap_or(0.0);
+        let avg = avg_kb.get(i).unwrap_or(0.0);
+        let cnt = count_col.get(i).unwrap_or(0);
+        let bsum = bytes_sum_col.get(i).unwrap_or(0.0);
+        let conc = concurrency_col
+            .as_ref()
+            .map_or(0, |c| c.get(i).unwrap_or(0));
 
         // Skip rows with zero count (empty buckets or invalid data)
         if cnt == 0 {
@@ -912,7 +1053,7 @@ fn compute_and_display_stats(df: &DataFrame, run_time_secs: f64, title: &str, pe
         // Compute throughput using per-op time range (fix for non-overlapping workloads, issue #14)
         let eff_time = op_eff_time(op);
         let ops = cnt as f64 / eff_time;
-        let xp  = bsum / (1024.0 * 1024.0 * eff_time);
+        let xp = bsum / (1024.0 * 1024.0 * eff_time);
 
         println!("{:>8} {:>12} {:>8} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9} {:>11} {:>9}",
                  op, bucket, bucket_num,
@@ -935,15 +1076,17 @@ fn compute_and_display_stats(df: &DataFrame, run_time_secs: f64, title: &str, pe
     println!(); // Separator line before summaries
 
     compute_and_print_summary_row(df, run_time_secs, meta_time, "META", &META_OPS, 97)?;
-    compute_and_print_summary_row(df, run_time_secs, get_time,  "GET",  &["GET"],  98)?;
-    compute_and_print_summary_row(df, run_time_secs, put_time,  "PUT",  &["PUT"],  99)?;
+    compute_and_print_summary_row(df, run_time_secs, get_time, "GET", &["GET"], 98)?;
+    compute_and_print_summary_row(df, run_time_secs, put_time, "PUT", &["PUT"], 99)?;
 
     // Print grand total
     let total_ops: u64 = count_col.into_iter().flatten().map(|x| x as u64).sum();
     let total_ops_sec: f64 = total_ops as f64 / run_time_secs;
-    println!("\nTotal operations: {}  ({:.2}/sec)",
-             format_int_with_commas(total_ops as i64),
-             total_ops_sec);
+    println!(
+        "\nTotal operations: {}  ({:.2}/sec)",
+        format_int_with_commas(total_ops as i64),
+        total_ops_sec
+    );
 
     // Print per-client statistics if requested
     if per_client {
@@ -967,46 +1110,66 @@ fn compute_and_print_per_client_stats(df: &DataFrame, run_time_secs: f64) -> Res
     }
 
     // Get unique client_ids
-    let unique_clients = df.column("client_id")?
-        .unique()?;
+    let unique_clients = df.column("client_id")?.unique()?;
     let client_ids = unique_clients
         .str()?
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
-    
+
     if client_ids.len() <= 1 {
         println!("\nOnly one client detected, skipping per-client statistics.");
         return Ok(());
     }
-    
+
     println!("\n{}", "=".repeat(80));
-    println!("Per-Client Statistics ({} clients detected)", client_ids.len());
+    println!(
+        "Per-Client Statistics ({} clients detected)",
+        client_ids.len()
+    );
     println!("{}", "=".repeat(80));
-    
+
     // Compute overall stats per client
-    let client_stats = df.clone().lazy()
+    let client_stats = df
+        .clone()
+        .lazy()
         .group_by([col("client_id")])
         .agg([
             (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
             (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90_lat_us"),
-            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95_lat_us"),
-            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
+            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p90_lat_us"),
+            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p95_lat_us"),
+            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p99_lat_us"),
             (col("duration_ns").max() / lit(1000.0)).alias("max_lat_us"),
             (col("bytes").mean() / lit(1024.0)).alias("avg_obj_KB"),
             (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops_per_sec"),
-            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xput_MBps"),
+            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                / lit(run_time_secs))
+            .alias("xput_MBps"),
             col("op").count().alias("count"),
         ])
         .sort(["client_id"], SortMultipleOptions::default())
         .collect()?;
-    
+
     // Print header
-    println!("{:>15} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
-             "client_id", "mean_lat_us", "med._lat_us", "90%_lat_us", "95%_lat_us", 
-             "99%_lat_us", "max_lat_us", "avg_obj_KB", "ops_/_sec", "xput_MBps", "count");
-    
+    println!(
+        "{:>15} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
+        "client_id",
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "max_lat_us",
+        "avg_obj_KB",
+        "ops_/_sec",
+        "xput_MBps",
+        "count"
+    );
+
     // Print each client
     let client_col = client_stats.column("client_id")?.str()?;
     let mean_lat = client_stats.column("mean_lat_us")?.f64()?;
@@ -1019,7 +1182,7 @@ fn compute_and_print_per_client_stats(df: &DataFrame, run_time_secs: f64) -> Res
     let ops_sec = client_stats.column("ops_per_sec")?.f64()?;
     let xput = client_stats.column("xput_MBps")?.f64()?;
     let count_col = client_stats.column("count")?.u32()?;
-    
+
     for i in 0..client_stats.height() {
         let client = client_col.get(i).unwrap_or("?");
         let mean = mean_lat.get(i).unwrap_or(0.0);
@@ -1032,61 +1195,77 @@ fn compute_and_print_per_client_stats(df: &DataFrame, run_time_secs: f64) -> Res
         let ops = ops_sec.get(i).unwrap_or(0.0);
         let xp = xput.get(i).unwrap_or(0.0);
         let cnt = count_col.get(i).unwrap_or(0);
-        
-        println!("{:>15} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
-                 client,
-                 format_with_commas(mean),
-                 format_with_commas(med),
-                 format_with_commas(p90),
-                 format_with_commas(p95),
-                 format_with_commas(p99),
-                 format_with_commas(max),
-                 format_with_commas(avg),
-                 format_with_commas(ops),
-                 format_with_commas(xp),
-                 format_int_with_commas(cnt as i64));
+
+        println!(
+            "{:>15} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
+            client,
+            format_with_commas(mean),
+            format_with_commas(med),
+            format_with_commas(p90),
+            format_with_commas(p95),
+            format_with_commas(p99),
+            format_with_commas(max),
+            format_with_commas(avg),
+            format_with_commas(ops),
+            format_with_commas(xp),
+            format_int_with_commas(cnt as i64)
+        );
     }
-    
+
     // Print per-client stats by operation type
     println!("\nPer-Client Statistics by Operation Type:");
     println!("{}", "-".repeat(80));
-    
+
     // Define operation categories
     let categories = vec![
         ("META", META_OPS.to_vec()),
         ("GET", vec!["GET"]),
         ("PUT", vec!["PUT"]),
     ];
-    
+
     for (op_name, ops_list) in categories {
         // Build filter for this operation category
         let mut filter_expr = lit(false);
         for op in &ops_list {
             filter_expr = filter_expr.or(col("op").eq(lit(*op)));
         }
-        
-        let op_client_stats = df.clone().lazy()
+
+        let op_client_stats = df
+            .clone()
+            .lazy()
             .filter(filter_expr)
             .group_by([col("client_id")])
             .agg([
                 (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
                 (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
-                (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops_per_sec"),
-                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xput_MBps"),
+                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                    .alias("p99_lat_us"),
+                (col("op").count().cast(DataType::Float64) / lit(run_time_secs))
+                    .alias("ops_per_sec"),
+                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                    / lit(run_time_secs))
+                .alias("xput_MBps"),
                 col("op").count().alias("count"),
             ])
             .sort(["client_id"], SortMultipleOptions::default())
             .collect()?;
-        
+
         if op_client_stats.height() == 0 {
             continue;
         }
-        
+
         println!("\n{} Operations:", op_name);
-        println!("{:>15} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
-                 "client_id", "mean_lat_us", "med._lat_us", "99%_lat_us", "ops_/_sec", "xput_MBps", "count");
-        
+        println!(
+            "{:>15} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
+            "client_id",
+            "mean_lat_us",
+            "med._lat_us",
+            "99%_lat_us",
+            "ops_/_sec",
+            "xput_MBps",
+            "count"
+        );
+
         let client_col = op_client_stats.column("client_id")?.str()?;
         let mean_lat = op_client_stats.column("mean_lat_us")?.f64()?;
         let med_lat = op_client_stats.column("med_lat_us")?.f64()?;
@@ -1094,7 +1273,7 @@ fn compute_and_print_per_client_stats(df: &DataFrame, run_time_secs: f64) -> Res
         let ops_sec = op_client_stats.column("ops_per_sec")?.f64()?;
         let xput = op_client_stats.column("xput_MBps")?.f64()?;
         let count_col = op_client_stats.column("count")?.u32()?;
-        
+
         for i in 0..op_client_stats.height() {
             let client = client_col.get(i).unwrap_or("?");
             let mean = mean_lat.get(i).unwrap_or(0.0);
@@ -1103,20 +1282,22 @@ fn compute_and_print_per_client_stats(df: &DataFrame, run_time_secs: f64) -> Res
             let ops = ops_sec.get(i).unwrap_or(0.0);
             let xp = xput.get(i).unwrap_or(0.0);
             let cnt = count_col.get(i).unwrap_or(0);
-            
-            println!("{:>15} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
-                     client,
-                     format_with_commas(mean),
-                     format_with_commas(med),
-                     format_with_commas(p99),
-                     format_with_commas(ops),
-                     format_with_commas(xp),
-                     format_int_with_commas(cnt as i64));
+
+            println!(
+                "{:>15} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
+                client,
+                format_with_commas(mean),
+                format_with_commas(med),
+                format_with_commas(p99),
+                format_with_commas(ops),
+                format_with_commas(xp),
+                format_int_with_commas(cnt as i64)
+            );
         }
     }
-    
+
     println!("\n{}\n", "=".repeat(80));
-    
+
     Ok(())
 }
 
@@ -1142,74 +1323,97 @@ fn compute_and_print_per_endpoint_stats(df: &DataFrame, run_time_secs: f64) -> R
     }
 
     println!("\n{}", "=".repeat(80));
-    println!("Per-Endpoint Statistics ({} endpoints detected)", endpoints.len());
+    println!(
+        "Per-Endpoint Statistics ({} endpoints detected)",
+        endpoints.len()
+    );
     println!("{}", "=".repeat(80));
 
     // Compute overall stats per endpoint
-    let endpoint_stats = df.clone().lazy()
+    let endpoint_stats = df
+        .clone()
+        .lazy()
         .group_by([col("endpoint")])
         .agg([
             (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
             (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90_lat_us"),
-            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95_lat_us"),
-            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
+            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p90_lat_us"),
+            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p95_lat_us"),
+            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p99_lat_us"),
             (col("duration_ns").max() / lit(1000.0)).alias("max_lat_us"),
             (col("bytes").mean() / lit(1024.0)).alias("avg_obj_KB"),
             (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops_per_sec"),
-            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xput_MBps"),
+            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                / lit(run_time_secs))
+            .alias("xput_MBps"),
             col("op").count().alias("count"),
         ])
         .sort(["endpoint"], SortMultipleOptions::default())
         .collect()?;
 
     // Print header
-    println!("{:>30} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
-             "endpoint", "mean_lat_us", "med._lat_us", "90%_lat_us", "95%_lat_us",
-             "99%_lat_us", "max_lat_us", "avg_obj_KB", "ops_/_sec", "xput_MBps", "count");
+    println!(
+        "{:>30} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
+        "endpoint",
+        "mean_lat_us",
+        "med._lat_us",
+        "90%_lat_us",
+        "95%_lat_us",
+        "99%_lat_us",
+        "max_lat_us",
+        "avg_obj_KB",
+        "ops_/_sec",
+        "xput_MBps",
+        "count"
+    );
 
-    let ep_col   = endpoint_stats.column("endpoint")?.str()?;
+    let ep_col = endpoint_stats.column("endpoint")?.str()?;
     let mean_lat = endpoint_stats.column("mean_lat_us")?.f64()?;
-    let med_lat  = endpoint_stats.column("med_lat_us")?.f64()?;
-    let p90_lat  = endpoint_stats.column("p90_lat_us")?.f64()?;
-    let p95_lat  = endpoint_stats.column("p95_lat_us")?.f64()?;
-    let p99_lat  = endpoint_stats.column("p99_lat_us")?.f64()?;
-    let max_lat  = endpoint_stats.column("max_lat_us")?.f64()?;
-    let avg_kb   = endpoint_stats.column("avg_obj_KB")?.f64()?;
-    let ops_sec  = endpoint_stats.column("ops_per_sec")?.f64()?;
-    let xput     = endpoint_stats.column("xput_MBps")?.f64()?;
+    let med_lat = endpoint_stats.column("med_lat_us")?.f64()?;
+    let p90_lat = endpoint_stats.column("p90_lat_us")?.f64()?;
+    let p95_lat = endpoint_stats.column("p95_lat_us")?.f64()?;
+    let p99_lat = endpoint_stats.column("p99_lat_us")?.f64()?;
+    let max_lat = endpoint_stats.column("max_lat_us")?.f64()?;
+    let avg_kb = endpoint_stats.column("avg_obj_KB")?.f64()?;
+    let ops_sec = endpoint_stats.column("ops_per_sec")?.f64()?;
+    let xput = endpoint_stats.column("xput_MBps")?.f64()?;
     let count_col = endpoint_stats.column("count")?.u32()?;
 
     for i in 0..endpoint_stats.height() {
-        let ep   = ep_col.get(i).unwrap_or("?");
+        let ep = ep_col.get(i).unwrap_or("?");
         let mean = mean_lat.get(i).unwrap_or(0.0);
-        let med  = med_lat.get(i).unwrap_or(0.0);
-        let p90  = p90_lat.get(i).unwrap_or(0.0);
-        let p95  = p95_lat.get(i).unwrap_or(0.0);
-        let p99  = p99_lat.get(i).unwrap_or(0.0);
-        let max  = max_lat.get(i).unwrap_or(0.0);
-        let avg  = avg_kb.get(i).unwrap_or(0.0);
-        let ops  = ops_sec.get(i).unwrap_or(0.0);
-        let xp   = xput.get(i).unwrap_or(0.0);
-        let cnt  = count_col.get(i).unwrap_or(0);
+        let med = med_lat.get(i).unwrap_or(0.0);
+        let p90 = p90_lat.get(i).unwrap_or(0.0);
+        let p95 = p95_lat.get(i).unwrap_or(0.0);
+        let p99 = p99_lat.get(i).unwrap_or(0.0);
+        let max = max_lat.get(i).unwrap_or(0.0);
+        let avg = avg_kb.get(i).unwrap_or(0.0);
+        let ops = ops_sec.get(i).unwrap_or(0.0);
+        let xp = xput.get(i).unwrap_or(0.0);
+        let cnt = count_col.get(i).unwrap_or(0);
 
         // Skip null/unknown endpoints and zero-count rows
         if cnt == 0 || ep == "?" {
             continue;
         }
 
-        println!("{:>30} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
-                 ep,
-                 format_with_commas(mean),
-                 format_with_commas(med),
-                 format_with_commas(p90),
-                 format_with_commas(p95),
-                 format_with_commas(p99),
-                 format_with_commas(max),
-                 format_with_commas(avg),
-                 format_with_commas(ops),
-                 format_with_commas(xp),
-                 format_int_with_commas(cnt as i64));
+        println!(
+            "{:>30} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9}",
+            ep,
+            format_with_commas(mean),
+            format_with_commas(med),
+            format_with_commas(p90),
+            format_with_commas(p95),
+            format_with_commas(p99),
+            format_with_commas(max),
+            format_with_commas(avg),
+            format_with_commas(ops),
+            format_with_commas(xp),
+            format_int_with_commas(cnt as i64)
+        );
     }
 
     // Print per-endpoint stats by operation type
@@ -1228,15 +1432,21 @@ fn compute_and_print_per_endpoint_stats(df: &DataFrame, run_time_secs: f64) -> R
             filter_expr = filter_expr.or(col("op").eq(lit(*op)));
         }
 
-        let op_ep_stats = df.clone().lazy()
+        let op_ep_stats = df
+            .clone()
+            .lazy()
             .filter(filter_expr)
             .group_by([col("endpoint")])
             .agg([
                 (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
                 (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
-                (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops_per_sec"),
-                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xput_MBps"),
+                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                    .alias("p99_lat_us"),
+                (col("op").count().cast(DataType::Float64) / lit(run_time_secs))
+                    .alias("ops_per_sec"),
+                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                    / lit(run_time_secs))
+                .alias("xput_MBps"),
                 col("op").count().alias("count"),
             ])
             .sort(["endpoint"], SortMultipleOptions::default())
@@ -1247,39 +1457,49 @@ fn compute_and_print_per_endpoint_stats(df: &DataFrame, run_time_secs: f64) -> R
         }
 
         println!("\n{} Operations:", op_name);
-        println!("{:>30} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
-                 "endpoint", "mean_lat_us", "med._lat_us", "99%_lat_us", "ops_/_sec", "xput_MBps", "count");
+        println!(
+            "{:>30} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
+            "endpoint",
+            "mean_lat_us",
+            "med._lat_us",
+            "99%_lat_us",
+            "ops_/_sec",
+            "xput_MBps",
+            "count"
+        );
 
-        let ep_col    = op_ep_stats.column("endpoint")?.str()?;
-        let mean_lat  = op_ep_stats.column("mean_lat_us")?.f64()?;
-        let med_lat   = op_ep_stats.column("med_lat_us")?.f64()?;
-        let p99_lat   = op_ep_stats.column("p99_lat_us")?.f64()?;
-        let ops_sec   = op_ep_stats.column("ops_per_sec")?.f64()?;
-        let xput      = op_ep_stats.column("xput_MBps")?.f64()?;
+        let ep_col = op_ep_stats.column("endpoint")?.str()?;
+        let mean_lat = op_ep_stats.column("mean_lat_us")?.f64()?;
+        let med_lat = op_ep_stats.column("med_lat_us")?.f64()?;
+        let p99_lat = op_ep_stats.column("p99_lat_us")?.f64()?;
+        let ops_sec = op_ep_stats.column("ops_per_sec")?.f64()?;
+        let xput = op_ep_stats.column("xput_MBps")?.f64()?;
         let count_col = op_ep_stats.column("count")?.u32()?;
 
         for i in 0..op_ep_stats.height() {
-            let ep  = ep_col.get(i).unwrap_or("?");
+            let ep = ep_col.get(i).unwrap_or("?");
             let mean = mean_lat.get(i).unwrap_or(0.0);
-            let med  = med_lat.get(i).unwrap_or(0.0);
-            let p99  = p99_lat.get(i).unwrap_or(0.0);
-            let ops  = ops_sec.get(i).unwrap_or(0.0);
-            let xp   = xput.get(i).unwrap_or(0.0);
-            let cnt  = count_col.get(i).unwrap_or(0);
+            let med = med_lat.get(i).unwrap_or(0.0);
+            let p99 = p99_lat.get(i).unwrap_or(0.0);
+            let ops = ops_sec.get(i).unwrap_or(0.0);
+            let xp = xput.get(i).unwrap_or(0.0);
+            let cnt = count_col.get(i).unwrap_or(0);
 
             // Skip null/unknown endpoints and zero-count rows
             if cnt == 0 || ep == "?" {
                 continue;
             }
 
-            println!("{:>30} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
-                     ep,
-                     format_with_commas(mean),
-                     format_with_commas(med),
-                     format_with_commas(p99),
-                     format_with_commas(ops),
-                     format_with_commas(xp),
-                     format_int_with_commas(cnt as i64));
+            println!(
+                "{:>30} {:>11} {:>11} {:>10} {:>9} {:>9} {:>9}",
+                ep,
+                format_with_commas(mean),
+                format_with_commas(med),
+                format_with_commas(p99),
+                format_with_commas(ops),
+                format_with_commas(xp),
+                format_int_with_commas(cnt as i64)
+            );
         }
     }
 
@@ -1312,19 +1532,27 @@ fn compute_and_print_summary_row(
     let mut select_exprs: Vec<Expr> = vec![
         (col("duration_ns").mean() / lit(1000.0)).alias("mean_lat_us"),
         (col("duration_ns").median() / lit(1000.0)).alias("med_lat_us"),
-        (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90_lat_us"),
-        (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95_lat_us"),
-        (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99_lat_us"),
+        (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p90_lat_us"),
+        (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p95_lat_us"),
+        (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+            .alias("p99_lat_us"),
         (col("duration_ns").max() / lit(1000.0)).alias("max_lat_us"),
         (col("bytes").mean() / lit(1024.0)).alias("avg_obj_KB"),
         col("op").count().alias("count"),
-        col("bytes").sum().cast(DataType::Float64).alias("bytes_sum"),
+        col("bytes")
+            .sum()
+            .cast(DataType::Float64)
+            .alias("bytes_sum"),
     ];
     if has_thread {
         select_exprs.push(col("thread").n_unique().alias("max_threads"));
     }
 
-    let category_stats = df.clone().lazy()
+    let category_stats = df
+        .clone()
+        .lazy()
         .filter(filter_expr)
         .select(select_exprs)
         .collect()?;
@@ -1340,22 +1568,64 @@ fn compute_and_print_summary_row(
     }
 
     // Use per-op time for throughput (issue #14 fix: correct for non-overlapping workloads)
-    let eff_time = if op_run_time > 0.0 { op_run_time } else { run_time_secs };
+    let eff_time = if op_run_time > 0.0 {
+        op_run_time
+    } else {
+        run_time_secs
+    };
 
-    let mean  = category_stats.column("mean_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let med   = category_stats.column("med_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let p90   = category_stats.column("p90_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let p95   = category_stats.column("p95_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let p99   = category_stats.column("p99_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let max   = category_stats.column("max_lat_us")?.f64()?.get(0).unwrap_or(0.0);
-    let avg   = category_stats.column("avg_obj_KB")?.f64()?.get(0).unwrap_or(0.0);
-    let bsum  = category_stats.column("bytes_sum")?.f64()?.get(0).unwrap_or(0.0);
+    let mean = category_stats
+        .column("mean_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let med = category_stats
+        .column("med_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let p90 = category_stats
+        .column("p90_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let p95 = category_stats
+        .column("p95_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let p99 = category_stats
+        .column("p99_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let max = category_stats
+        .column("max_lat_us")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let avg = category_stats
+        .column("avg_obj_KB")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
+    let bsum = category_stats
+        .column("bytes_sum")?
+        .f64()?
+        .get(0)
+        .unwrap_or(0.0);
     let n_thr: u32 = if has_thread {
-        category_stats.column("max_threads")?.u32()?.get(0).unwrap_or(0)
-    } else { 0 };
+        category_stats
+            .column("max_threads")?
+            .u32()?
+            .get(0)
+            .unwrap_or(0)
+    } else {
+        0
+    };
 
     let ops = count as f64 / eff_time;
-    let xp  = bsum / (1024.0 * 1024.0 * eff_time);
+    let xp = bsum / (1024.0 * 1024.0 * eff_time);
 
     println!("{:>8} {:>12} {:>8} {:>11} {:>11} {:>10} {:>10} {:>10} {:>10} {:>10} {:>9} {:>9} {:>9} {:>11} {:>9}",
              category, "ALL", bucket_idx,
@@ -1382,7 +1652,10 @@ fn print_basic_stats(df: &DataFrame) {
     // Print column names and types
     println!("\nColumns:");
     for name in df.get_column_names() {
-        let dtype = df.column(name).map(|s| s.dtype().clone()).unwrap_or(DataType::Null);
+        let dtype = df
+            .column(name)
+            .map(|s| s.dtype().clone())
+            .unwrap_or(DataType::Null);
         println!("  - {}: {}", name, dtype);
     }
 
@@ -1424,24 +1697,33 @@ fn read_summary_file(file_path: &str) -> Result<DataFrame> {
     }
 
     let required = ["op", "start", "end", "bps", "ops_per_sec", "errors"];
-    let cols: Vec<String> = df.get_column_names().iter().map(|s| s.to_string()).collect();
-    let missing: Vec<&str> = required.iter()
+    let cols: Vec<String> = df
+        .get_column_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let missing: Vec<&str> = required
+        .iter()
         .filter(|c| !cols.contains(&c.to_string()))
         .copied()
         .collect();
     if !missing.is_empty() {
         anyhow::bail!(
             "Summary file '{}' is missing required columns: {}",
-            file_path, missing.join(", ")
+            file_path,
+            missing.join(", ")
         );
     }
 
     // Parse start/end to nanosecond timestamps for time-range computation
-    let df = df.lazy()
+    let df = df
+        .lazy()
         .with_columns([
             col("start")
-                .str().replace(lit("Z$"), lit("+00:00"), false)
-                .str().to_datetime(
+                .str()
+                .replace(lit("Z$"), lit("+00:00"), false)
+                .str()
+                .to_datetime(
                     Some(TimeUnit::Nanoseconds),
                     None,
                     StrptimeOptions {
@@ -1452,11 +1734,14 @@ fn read_summary_file(file_path: &str) -> Result<DataFrame> {
                     },
                     lit("raise"),
                 )
-                .dt().timestamp(TimeUnit::Nanoseconds)
+                .dt()
+                .timestamp(TimeUnit::Nanoseconds)
                 .alias("start_ns"),
             col("end")
-                .str().replace(lit("Z$"), lit("+00:00"), false)
-                .str().to_datetime(
+                .str()
+                .replace(lit("Z$"), lit("+00:00"), false)
+                .str()
+                .to_datetime(
                     Some(TimeUnit::Nanoseconds),
                     None,
                     StrptimeOptions {
@@ -1467,7 +1752,8 @@ fn read_summary_file(file_path: &str) -> Result<DataFrame> {
                     },
                     lit("raise"),
                 )
-                .dt().timestamp(TimeUnit::Nanoseconds)
+                .dt()
+                .timestamp(TimeUnit::Nanoseconds)
                 .alias("end_ns"),
             // Ensure bps is f64 (may be read as i64 if all values are whole numbers)
             col("bps").cast(DataType::Float64),
@@ -1483,14 +1769,27 @@ fn process_summary_file(file_path: &str) -> Result<(DataFrame, i64, i64)> {
     let df = read_summary_file(file_path)?;
 
     // Derive time range from start_ns / end_ns columns
-    let start_ns = df.column("start_ns")?.i64()?.into_iter().flatten().next()
+    let start_ns = df
+        .column("start_ns")?
+        .i64()?
+        .into_iter()
+        .flatten()
+        .next()
         .context("Could not determine start time from summary file")?;
-    let end_ns = df.column("end_ns")?.i64()?.into_iter().flatten().last()
+    let end_ns = df
+        .column("end_ns")?
+        .i64()?
+        .into_iter()
+        .flatten()
+        .last()
         .context("Could not determine end time from summary file")?;
 
     let seg_count = df.height();
     let duration_secs = (end_ns - start_ns) as f64 / 1_000_000_000.0;
-    println!("Time range: {} seconds  ({} segments)", duration_secs as i64, seg_count);
+    println!(
+        "Time range: {} seconds  ({} segments)",
+        duration_secs as i64, seg_count
+    );
 
     compute_and_display_summary_stats(&df)?;
 
@@ -1500,27 +1799,33 @@ fn process_summary_file(file_path: &str) -> Result<(DataFrame, i64, i64)> {
 /// Compute and display per-op throughput variability statistics from a summary DataFrame.
 /// Columns: op, bps, ops_per_sec, errors  (plus start_ns/end_ns)
 fn compute_and_display_summary_stats(df: &DataFrame) -> Result<()> {
-    let stats = df.clone().lazy()
+    let stats = df
+        .clone()
+        .lazy()
         .group_by([col("op")])
         .agg([
             col("bps").count().alias("segments"),
-            (col("bps").mean()     / lit(1_048_576.0)).alias("mean_MBps"),
-            (col("bps").median()   / lit(1_048_576.0)).alias("p50_MBps"),
-            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p90_MBps"),
-            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p99_MBps"),
-            (col("bps").min()      / lit(1_048_576.0)).alias("min_MBps"),
-            (col("bps").max()      / lit(1_048_576.0)).alias("max_MBps"),
-            (col("bps").std(1)     / lit(1_048_576.0)).alias("stdev_MBps"),
+            (col("bps").mean() / lit(1_048_576.0)).alias("mean_MBps"),
+            (col("bps").median() / lit(1_048_576.0)).alias("p50_MBps"),
+            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0))
+                .alias("p90_MBps"),
+            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0))
+                .alias("p99_MBps"),
+            (col("bps").min() / lit(1_048_576.0)).alias("min_MBps"),
+            (col("bps").max() / lit(1_048_576.0)).alias("max_MBps"),
+            (col("bps").std(1) / lit(1_048_576.0)).alias("stdev_MBps"),
             col("ops_per_sec").mean().alias("mean_ops"),
             col("ops_per_sec").median().alias("p50_ops"),
-            col("ops_per_sec").quantile(lit(0.99), QuantileMethod::Linear).alias("p99_ops"),
-            col("errors").cast(DataType::Int64).sum().alias("total_errors"),
+            col("ops_per_sec")
+                .quantile(lit(0.99), QuantileMethod::Linear)
+                .alias("p99_ops"),
+            col("errors")
+                .cast(DataType::Int64)
+                .sum()
+                .alias("total_errors"),
         ])
         // Sort: TOTAL last, everything else alphabetical
-        .sort(
-            ["op"],
-            SortMultipleOptions::default(),
-        )
+        .sort(["op"], SortMultipleOptions::default())
         .collect()?;
 
     if stats.height() == 0 {
@@ -1530,43 +1835,51 @@ fn compute_and_display_summary_stats(df: &DataFrame) -> Result<()> {
 
     println!(
         "{:>8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>13}",
-        "op", "segs",
-        "mean_MBps", "p50_MBps", "p90_MBps", "p99_MBps",
-        "min_MBps", "max_MBps", "stdev_MBps",
-        "mean_ops/s", "p50_ops/s", "p99_ops/s",
+        "op",
+        "segs",
+        "mean_MBps",
+        "p50_MBps",
+        "p90_MBps",
+        "p99_MBps",
+        "min_MBps",
+        "max_MBps",
+        "stdev_MBps",
+        "mean_ops/s",
+        "p50_ops/s",
+        "p99_ops/s",
         "total_errors"
     );
 
-    let op_col     = stats.column("op")?.str()?;
-    let segs_col   = stats.column("segments")?.u32()?;
-    let mean_col   = stats.column("mean_MBps")?.f64()?;
-    let p50_col    = stats.column("p50_MBps")?.f64()?;
-    let p90_col    = stats.column("p90_MBps")?.f64()?;
-    let p99_col    = stats.column("p99_MBps")?.f64()?;
-    let min_col    = stats.column("min_MBps")?.f64()?;
-    let max_col    = stats.column("max_MBps")?.f64()?;
-    let stdev_col  = stats.column("stdev_MBps")?.f64()?;
-    let mops_col   = stats.column("mean_ops")?.f64()?;
+    let op_col = stats.column("op")?.str()?;
+    let segs_col = stats.column("segments")?.u32()?;
+    let mean_col = stats.column("mean_MBps")?.f64()?;
+    let p50_col = stats.column("p50_MBps")?.f64()?;
+    let p90_col = stats.column("p90_MBps")?.f64()?;
+    let p99_col = stats.column("p99_MBps")?.f64()?;
+    let min_col = stats.column("min_MBps")?.f64()?;
+    let max_col = stats.column("max_MBps")?.f64()?;
+    let stdev_col = stats.column("stdev_MBps")?.f64()?;
+    let mops_col = stats.column("mean_ops")?.f64()?;
     let p50ops_col = stats.column("p50_ops")?.f64()?;
     let p99ops_col = stats.column("p99_ops")?.f64()?;
-    let errs_col   = stats.column("total_errors")?.i64()?;
+    let errs_col = stats.column("total_errors")?.i64()?;
 
     // Print non-TOTAL rows first, then TOTAL
     let height = stats.height();
     let print_row = |i: usize| {
-        let op    = op_col.get(i).unwrap_or("?");
-        let segs  = segs_col.get(i).unwrap_or(0);
-        let mean  = mean_col.get(i).unwrap_or(0.0);
-        let p50   = p50_col.get(i).unwrap_or(0.0);
-        let p90   = p90_col.get(i).unwrap_or(0.0);
-        let p99   = p99_col.get(i).unwrap_or(0.0);
-        let min   = min_col.get(i).unwrap_or(0.0);
-        let max   = max_col.get(i).unwrap_or(0.0);
-        let std   = stdev_col.get(i).unwrap_or(0.0);
-        let mops  = mops_col.get(i).unwrap_or(0.0);
+        let op = op_col.get(i).unwrap_or("?");
+        let segs = segs_col.get(i).unwrap_or(0);
+        let mean = mean_col.get(i).unwrap_or(0.0);
+        let p50 = p50_col.get(i).unwrap_or(0.0);
+        let p90 = p90_col.get(i).unwrap_or(0.0);
+        let p99 = p99_col.get(i).unwrap_or(0.0);
+        let min = min_col.get(i).unwrap_or(0.0);
+        let max = max_col.get(i).unwrap_or(0.0);
+        let std = stdev_col.get(i).unwrap_or(0.0);
+        let mops = mops_col.get(i).unwrap_or(0.0);
         let p50op = p50ops_col.get(i).unwrap_or(0.0);
         let p99op = p99ops_col.get(i).unwrap_or(0.0);
-        let errs  = errs_col.get(i).unwrap_or(0);
+        let errs = errs_col.get(i).unwrap_or(0);
         println!(
             "{:>8} {:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>10} {:>13}",
             op, segs,
@@ -1596,46 +1909,63 @@ fn compute_and_display_summary_stats(df: &DataFrame) -> Result<()> {
 
 /// Collect summary stats rows for Excel export (header + data rows, no commas in numbers).
 fn collect_summary_excel_rows(df: &DataFrame) -> Result<Vec<Vec<String>>> {
-    let stats = df.clone().lazy()
+    let stats = df
+        .clone()
+        .lazy()
         .group_by([col("op")])
         .agg([
             col("bps").count().alias("segments"),
-            (col("bps").mean()     / lit(1_048_576.0)).alias("mean_MBps"),
-            (col("bps").median()   / lit(1_048_576.0)).alias("p50_MBps"),
-            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p90_MBps"),
-            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0)).alias("p99_MBps"),
-            (col("bps").min()      / lit(1_048_576.0)).alias("min_MBps"),
-            (col("bps").max()      / lit(1_048_576.0)).alias("max_MBps"),
-            (col("bps").std(1)     / lit(1_048_576.0)).alias("stdev_MBps"),
+            (col("bps").mean() / lit(1_048_576.0)).alias("mean_MBps"),
+            (col("bps").median() / lit(1_048_576.0)).alias("p50_MBps"),
+            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0))
+                .alias("p90_MBps"),
+            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0))
+                .alias("p99_MBps"),
+            (col("bps").min() / lit(1_048_576.0)).alias("min_MBps"),
+            (col("bps").max() / lit(1_048_576.0)).alias("max_MBps"),
+            (col("bps").std(1) / lit(1_048_576.0)).alias("stdev_MBps"),
             col("ops_per_sec").mean().alias("mean_ops"),
             col("ops_per_sec").median().alias("p50_ops"),
-            col("ops_per_sec").quantile(lit(0.99), QuantileMethod::Linear).alias("p99_ops"),
-            col("errors").cast(DataType::Int64).sum().alias("total_errors"),
+            col("ops_per_sec")
+                .quantile(lit(0.99), QuantileMethod::Linear)
+                .alias("p99_ops"),
+            col("errors")
+                .cast(DataType::Int64)
+                .sum()
+                .alias("total_errors"),
         ])
         .sort(["op"], SortMultipleOptions::default())
         .collect()?;
 
     let mut rows: Vec<Vec<String>> = vec![vec![
-        "op".into(), "segments".into(),
-        "mean_MBps".into(), "p50_MBps".into(), "p90_MBps".into(), "p99_MBps".into(),
-        "min_MBps".into(), "max_MBps".into(), "stdev_MBps".into(),
-        "mean_ops/s".into(), "p50_ops/s".into(), "p99_ops/s".into(),
+        "op".into(),
+        "segments".into(),
+        "mean_MBps".into(),
+        "p50_MBps".into(),
+        "p90_MBps".into(),
+        "p99_MBps".into(),
+        "min_MBps".into(),
+        "max_MBps".into(),
+        "stdev_MBps".into(),
+        "mean_ops/s".into(),
+        "p50_ops/s".into(),
+        "p99_ops/s".into(),
         "total_errors".into(),
     ]];
 
-    let op_col     = stats.column("op")?.str()?;
-    let segs_col   = stats.column("segments")?.u32()?;
-    let mean_col   = stats.column("mean_MBps")?.f64()?;
-    let p50_col    = stats.column("p50_MBps")?.f64()?;
-    let p90_col    = stats.column("p90_MBps")?.f64()?;
-    let p99_col    = stats.column("p99_MBps")?.f64()?;
-    let min_col    = stats.column("min_MBps")?.f64()?;
-    let max_col    = stats.column("max_MBps")?.f64()?;
-    let stdev_col  = stats.column("stdev_MBps")?.f64()?;
-    let mops_col   = stats.column("mean_ops")?.f64()?;
+    let op_col = stats.column("op")?.str()?;
+    let segs_col = stats.column("segments")?.u32()?;
+    let mean_col = stats.column("mean_MBps")?.f64()?;
+    let p50_col = stats.column("p50_MBps")?.f64()?;
+    let p90_col = stats.column("p90_MBps")?.f64()?;
+    let p99_col = stats.column("p99_MBps")?.f64()?;
+    let min_col = stats.column("min_MBps")?.f64()?;
+    let max_col = stats.column("max_MBps")?.f64()?;
+    let stdev_col = stats.column("stdev_MBps")?.f64()?;
+    let mops_col = stats.column("mean_ops")?.f64()?;
     let p50ops_col = stats.column("p50_ops")?.f64()?;
     let p99ops_col = stats.column("p99_ops")?.f64()?;
-    let errs_col   = stats.column("total_errors")?.i64()?;
+    let errs_col = stats.column("total_errors")?.i64()?;
 
     // Non-TOTAL rows first, then TOTAL
     let height = stats.height();
@@ -1657,10 +1987,14 @@ fn collect_summary_excel_rows(df: &DataFrame) -> Result<Vec<Vec<String>>> {
         ]);
     };
     for i in 0..height {
-        if op_col.get(i).unwrap_or("") != "TOTAL" { push_row(&mut rows, i); }
+        if op_col.get(i).unwrap_or("") != "TOTAL" {
+            push_row(&mut rows, i);
+        }
     }
     for i in 0..height {
-        if op_col.get(i).unwrap_or("") == "TOTAL" { push_row(&mut rows, i); }
+        if op_col.get(i).unwrap_or("") == "TOTAL" {
+            push_row(&mut rows, i);
+        }
     }
 
     Ok(rows)
@@ -1672,9 +2006,16 @@ fn derive_short_name(file_path: &str) -> String {
     let path = Path::new(file_path);
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
     let name = name.strip_suffix(".zst").unwrap_or(name);
-    let name = name.strip_suffix(".csv").or_else(|| name.strip_suffix(".tsv")).unwrap_or(name);
+    let name = name
+        .strip_suffix(".csv")
+        .or_else(|| name.strip_suffix(".tsv"))
+        .unwrap_or(name);
     // Strip warp-style [timestamp] and everything after
-    let name = if let Some(idx) = name.find('[') { &name[..idx] } else { name };
+    let name = if let Some(idx) = name.find('[') {
+        &name[..idx]
+    } else {
+        name
+    };
     let name = name.trim_end_matches(['-', '_', '.']);
     // Truncate to 20 chars to leave room for "-Results" / "-Detail" suffix
     if name.len() > 20 { &name[..20] } else { name }.to_string()
@@ -1687,10 +2028,19 @@ fn derive_excel_path(files: &[String]) -> String {
     if files.len() == 1 {
         let path = Path::new(&files[0]);
         let parent = path.parent().unwrap_or(Path::new("."));
-        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("output");
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("output");
         let name = name.strip_suffix(".zst").unwrap_or(name);
-        let name = name.strip_suffix(".csv").or_else(|| name.strip_suffix(".tsv")).unwrap_or(name);
-        parent.join(format!("{}.xlsx", name)).to_string_lossy().into_owned()
+        let name = name
+            .strip_suffix(".csv")
+            .or_else(|| name.strip_suffix(".tsv"))
+            .unwrap_or(name);
+        parent
+            .join(format!("{}.xlsx", name))
+            .to_string_lossy()
+            .into_owned()
     } else {
         "polarwarp-results.xlsx".to_string()
     }
@@ -1716,9 +2066,12 @@ fn write_excel_workbook_with_chart_tabs(
     chart_tabs: &[(DataFrame, String)],
 ) -> Result<()> {
     let mut workbook = Workbook::new();
-    let header_fmt  = Format::new().set_bold().set_font_name("Aptos");
-    let data_fmt    = Format::new().set_font_name("Aptos");
-    let section_fmt = Format::new().set_bold().set_font_name("Aptos").set_font_size(11.0);
+    let header_fmt = Format::new().set_bold().set_font_name("Aptos");
+    let data_fmt = Format::new().set_font_name("Aptos");
+    let section_fmt = Format::new()
+        .set_bold()
+        .set_font_name("Aptos")
+        .set_font_size(11.0);
 
     // Write regular (string-based) tabs — identical to write_excel_workbook
     for (tab_name, rows) in tabs {
@@ -1729,12 +2082,16 @@ fn write_excel_workbook_with_chart_tabs(
         ws.set_name(tab_name)?;
 
         for (row_idx, row) in rows.iter().enumerate() {
-            let is_section = row.len() == 1 &&
-                (row[0].starts_with("===") || row[0].starts_with("---"));
+            let is_section =
+                row.len() == 1 && (row[0].starts_with("===") || row[0].starts_with("---"));
 
             for (col_idx, cell) in row.iter().enumerate() {
                 let fmt = if row_idx == 0 || is_section {
-                    if is_section { &section_fmt } else { &header_fmt }
+                    if is_section {
+                        &section_fmt
+                    } else {
+                        &header_fmt
+                    }
                 } else {
                     &data_fmt
                 };
@@ -1748,7 +2105,8 @@ fn write_excel_workbook_with_chart_tabs(
 
         if let Some(header) = rows.first() {
             for col_idx in 0..header.len() {
-                let max_len = rows.iter()
+                let max_len = rows
+                    .iter()
                     .map(|r| r.get(col_idx).map_or(0, |c| c.len()))
                     .max()
                     .unwrap_or(10);
@@ -1762,7 +2120,9 @@ fn write_excel_workbook_with_chart_tabs(
         write_summary_chart_tab(&mut workbook, df, tab_name)?;
     }
 
-    workbook.save(path).with_context(|| format!("Failed to save Excel file: {}", path))?;
+    workbook
+        .save(path)
+        .with_context(|| format!("Failed to save Excel file: {}", path))?;
     Ok(())
 }
 
@@ -1772,13 +2132,11 @@ fn write_excel_workbook_with_chart_tabs(
 ///
 /// Column layout: [seconds | <op>_ops … | <op>_MBps …]
 /// Charts are inserted below the data table, side by side.
-fn write_summary_chart_tab(
-    workbook: &mut Workbook,
-    df: &DataFrame,
-    tab_name: &str,
-) -> Result<()> {
+fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &str) -> Result<()> {
     // Filter TOTAL rows; sort by time then op for deterministic ordering
-    let df_filt = df.clone().lazy()
+    let df_filt = df
+        .clone()
+        .lazy()
         .filter(col("op").neq(lit("TOTAL")))
         .sort(["start_ns", "op"], SortMultipleOptions::default())
         .collect()?;
@@ -1787,41 +2145,42 @@ fn write_summary_chart_tab(
         return Ok(());
     }
 
-    let op_col    = df_filt.column("op")?.str()?;
+    let op_col = df_filt.column("op")?.str()?;
     let start_col = df_filt.column("start_ns")?.i64()?;
-    let bps_col   = df_filt.column("bps")?.f64()?;
-    let ops_col   = df_filt.column("ops_per_sec")?.f64()?;
+    let bps_col = df_filt.column("bps")?.f64()?;
+    let ops_col = df_filt.column("ops_per_sec")?.f64()?;
 
     let min_ns = start_col.min().unwrap_or(0);
 
     // Collect unique ops (sorted) and unique second offsets (sorted)
-    let mut ops_set:  std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut secs_set: std::collections::HashSet<i64>    = std::collections::HashSet::new();
+    let mut ops_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut secs_set: std::collections::HashSet<i64> = std::collections::HashSet::new();
     for i in 0..df_filt.height() {
         ops_set.insert(op_col.get(i).unwrap_or("").to_string());
         secs_set.insert((start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000);
     }
-    let mut all_ops:  Vec<String> = ops_set.into_iter().collect();
+    let mut all_ops: Vec<String> = ops_set.into_iter().collect();
     all_ops.sort();
     let mut all_secs: Vec<i64> = secs_set.into_iter().collect();
     all_secs.sort();
 
     let n_rows = all_secs.len();
-    let n_ops  = all_ops.len();
+    let n_ops = all_ops.len();
 
     // Build per-(op, seconds) lookup → (ops_per_sec, MBps)
     let mut lookup: std::collections::HashMap<(String, i64), (f64, f64)> =
         std::collections::HashMap::new();
     for i in 0..df_filt.height() {
-        let op   = op_col.get(i).unwrap_or("").to_string();
+        let op = op_col.get(i).unwrap_or("").to_string();
         let secs = (start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000;
-        let ops  = ops_col.get(i).unwrap_or(0.0);
+        let ops = ops_col.get(i).unwrap_or(0.0);
         let mbps = bps_col.get(i).unwrap_or(0.0) / 1_048_576.0;
         lookup.insert((op, secs), (ops, mbps));
     }
 
     // ops for throughput chart: GET and PUT only (META has no byte payload)
-    let bw_ops: Vec<&String> = all_ops.iter()
+    let bw_ops: Vec<&String> = all_ops
+        .iter()
         .filter(|o| o.as_str() == "GET" || o.as_str() == "PUT")
         .collect();
 
@@ -1830,15 +2189,20 @@ fn write_summary_chart_tab(
     ws.set_name(tab_name)?;
 
     let header_fmt = Format::new().set_bold().set_font_name("Aptos");
-    let data_fmt   = Format::new().set_font_name("Aptos");
+    let data_fmt = Format::new().set_font_name("Aptos");
 
     // Header row: seconds | <op>_ops … | <op>_MBps …
     ws.write_string_with_format(0, 0, "seconds", &header_fmt)?;
     for (oi, op) in all_ops.iter().enumerate() {
-        ws.write_string_with_format(0, (oi + 1) as u16, &format!("{}_ops", op), &header_fmt)?;
+        ws.write_string_with_format(0, (oi + 1) as u16, format!("{}_ops", op), &header_fmt)?;
     }
     for (bi, op) in bw_ops.iter().enumerate() {
-        ws.write_string_with_format(0, (n_ops + 1 + bi) as u16, &format!("{}_MBps", op), &header_fmt)?;
+        ws.write_string_with_format(
+            0,
+            (n_ops + 1 + bi) as u16,
+            format!("{}_MBps", op),
+            &header_fmt,
+        )?;
     }
 
     // Data rows
@@ -1876,7 +2240,8 @@ fn write_summary_chart_tab(
 
         for (oi, op) in all_ops.iter().enumerate() {
             let data_col = (oi + 1) as u16;
-            chart_ops.add_series()
+            chart_ops
+                .add_series()
                 .set_name(op.as_str())
                 .set_categories((tab_name, 1, 0, n_rows as u32, 0))
                 .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
@@ -1894,7 +2259,8 @@ fn write_summary_chart_tab(
 
         for (bi, op) in bw_ops.iter().enumerate() {
             let data_col = (n_ops + 1 + bi) as u16;
-            chart_bw.add_series()
+            chart_bw
+                .add_series()
                 .set_name(op.as_str())
                 .set_categories((tab_name, 1, 0, n_rows as u32, 0))
                 .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
@@ -1919,14 +2285,23 @@ fn collect_stats_rows(
 ) -> Result<ExcelTabRows> {
     // Per-op effective time windows (issue #14)
     let meta_time = compute_op_run_time(df, &META_OPS).unwrap_or(run_time_secs);
-    let get_time  = compute_op_run_time(df, &["GET"]).unwrap_or(run_time_secs);
-    let put_time  = compute_op_run_time(df, &["PUT"]).unwrap_or(run_time_secs);
+    let get_time = compute_op_run_time(df, &["GET"]).unwrap_or(run_time_secs);
+    let put_time = compute_op_run_time(df, &["PUT"]).unwrap_or(run_time_secs);
     let op_eff = |op: &str| -> f64 {
-        let t = if META_OPS.contains(&op) { meta_time }
-                else if op == "GET" { get_time }
-                else if op == "PUT" { put_time }
-                else { run_time_secs };
-        if t > 0.0 { t } else { run_time_secs }
+        let t = if META_OPS.contains(&op) {
+            meta_time
+        } else if op == "GET" {
+            get_time
+        } else if op == "PUT" {
+            put_time
+        } else {
+            run_time_secs
+        };
+        if t > 0.0 {
+            t
+        } else {
+            run_time_secs
+        }
     };
 
     let has_thread = df.column("thread").is_ok();
@@ -1947,7 +2322,9 @@ fn collect_stats_rows(
         agg.push(col("thread").n_unique().alias("max_threads"));
     }
 
-    let stats = df.clone().lazy()
+    let stats = df
+        .clone()
+        .lazy()
         .group_by([col("op"), col("bytes_bucket"), col("bucket_num")])
         .agg(agg)
         .sort(["bucket_num", "op"], SortMultipleOptions::default())
@@ -1957,33 +2334,49 @@ fn collect_stats_rows(
 
     // Header row
     main_rows.push(vec![
-        "op".into(), "bytes_bucket".into(), "bucket_#".into(),
-        "mean_lat_us".into(), "med._lat_us".into(), "90%_lat_us".into(),
-        "95%_lat_us".into(), "99%_lat_us".into(), "max_lat_us".into(),
-        "avg_obj_KB".into(), "ops_/_sec".into(), "xput_MBps".into(), "count".into(),
-        "max_threads".into(), "runtime_s".into(),
+        "op".into(),
+        "bytes_bucket".into(),
+        "bucket_#".into(),
+        "mean_lat_us".into(),
+        "med._lat_us".into(),
+        "90%_lat_us".into(),
+        "95%_lat_us".into(),
+        "99%_lat_us".into(),
+        "max_lat_us".into(),
+        "avg_obj_KB".into(),
+        "ops_/_sec".into(),
+        "xput_MBps".into(),
+        "count".into(),
+        "max_threads".into(),
+        "runtime_s".into(),
     ]);
 
-    let op_c    = stats.column("op")?.str()?;
-    let bkt_c   = stats.column("bytes_bucket")?.str()?;
-    let bnum_c  = stats.column("bucket_num")?.i32()?;
-    let mean_c  = stats.column("mean")?.f64()?;
-    let med_c   = stats.column("med")?.f64()?;
-    let p90_c   = stats.column("p90")?.f64()?;
-    let p95_c   = stats.column("p95")?.f64()?;
-    let p99_c   = stats.column("p99")?.f64()?;
-    let max_c   = stats.column("max")?.f64()?;
-    let avg_c   = stats.column("avg")?.f64()?;
-    let cnt_c   = stats.column("count")?.u32()?;
-    let bsum_c  = stats.column("bsum")?.f64()?;
-    let conc_c  = if has_thread { Some(stats.column("max_threads")?.u32()?) } else { None };
+    let op_c = stats.column("op")?.str()?;
+    let bkt_c = stats.column("bytes_bucket")?.str()?;
+    let bnum_c = stats.column("bucket_num")?.i32()?;
+    let mean_c = stats.column("mean")?.f64()?;
+    let med_c = stats.column("med")?.f64()?;
+    let p90_c = stats.column("p90")?.f64()?;
+    let p95_c = stats.column("p95")?.f64()?;
+    let p99_c = stats.column("p99")?.f64()?;
+    let max_c = stats.column("max")?.f64()?;
+    let avg_c = stats.column("avg")?.f64()?;
+    let cnt_c = stats.column("count")?.u32()?;
+    let bsum_c = stats.column("bsum")?.f64()?;
+    let conc_c = if has_thread {
+        Some(stats.column("max_threads")?.u32()?)
+    } else {
+        None
+    };
 
     for i in 0..stats.height() {
         let cnt = cnt_c.get(i).unwrap_or(0);
-        if cnt == 0 { continue; }
-        let op   = op_c.get(i).unwrap_or("?");
+        if cnt == 0 {
+            continue;
+        }
+        let op = op_c.get(i).unwrap_or("?");
         let bsum = bsum_c.get(i).unwrap_or(0.0);
-        let eff  = op_eff(op);
+        let eff = op_eff(op);
         main_rows.push(vec![
             op.to_string(),
             bkt_c.get(i).unwrap_or("?").to_string(),
@@ -1998,7 +2391,10 @@ fn collect_stats_rows(
             format!("{:.2}", cnt as f64 / eff),
             format!("{:.2}", bsum / (1024.0 * 1024.0 * eff)),
             cnt.to_string(),
-            conc_c.as_ref().map_or(0, |c| c.get(i).unwrap_or(0)).to_string(),
+            conc_c
+                .as_ref()
+                .map_or(0, |c| c.get(i).unwrap_or(0))
+                .to_string(),
             format!("{:.1}", eff),
         ]);
     }
@@ -2006,36 +2402,60 @@ fn collect_stats_rows(
     // Summary (ALL) rows for META / GET / PUT
     for (category, ops_list, bucket_idx) in [
         ("META", META_OPS.as_slice(), 97i32),
-        ("GET",  ["GET"].as_slice(),  98i32),
-        ("PUT",  ["PUT"].as_slice(),  99i32),
+        ("GET", ["GET"].as_slice(), 98i32),
+        ("PUT", ["PUT"].as_slice(), 99i32),
     ] {
         let mut filt = lit(false);
-        for op in ops_list { filt = filt.or(col("op").eq(lit(*op))); }
+        for op in ops_list {
+            filt = filt.or(col("op").eq(lit(*op)));
+        }
 
         let mut sel: Vec<Expr> = vec![
             (col("duration_ns").mean() / lit(1000.0)).alias("mean"),
             (col("duration_ns").median() / lit(1000.0)).alias("med"),
-            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90"),
-            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95"),
-            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99"),
+            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p90"),
+            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p95"),
+            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p99"),
             (col("duration_ns").max() / lit(1000.0)).alias("max"),
             (col("bytes").mean() / lit(1024.0)).alias("avg"),
             col("op").count().alias("count"),
             col("bytes").sum().cast(DataType::Float64).alias("bsum"),
         ];
-        if has_thread { sel.push(col("thread").n_unique().alias("n_thr")); }
+        if has_thread {
+            sel.push(col("thread").n_unique().alias("n_thr"));
+        }
 
         let cs = df.clone().lazy().filter(filt).select(sel).collect()?;
         let cnt = cs.column("count")?.u32()?.get(0).unwrap_or(0);
-        if cnt == 0 { continue; }
+        if cnt == 0 {
+            continue;
+        }
 
-        let op_time = match category { "META" => meta_time, "GET" => get_time, "PUT" => put_time, _ => run_time_secs };
-        let eff = if op_time > 0.0 { op_time } else { run_time_secs };
-        let bsum  = cs.column("bsum")?.f64()?.get(0).unwrap_or(0.0);
-        let n_thr = if has_thread { cs.column("n_thr")?.u32()?.get(0).unwrap_or(0) } else { 0 };
+        let op_time = match category {
+            "META" => meta_time,
+            "GET" => get_time,
+            "PUT" => put_time,
+            _ => run_time_secs,
+        };
+        let eff = if op_time > 0.0 {
+            op_time
+        } else {
+            run_time_secs
+        };
+        let bsum = cs.column("bsum")?.f64()?.get(0).unwrap_or(0.0);
+        let n_thr = if has_thread {
+            cs.column("n_thr")?.u32()?.get(0).unwrap_or(0)
+        } else {
+            0
+        };
 
         main_rows.push(vec![
-            category.to_string(), "ALL".to_string(), bucket_idx.to_string(),
+            category.to_string(),
+            "ALL".to_string(),
+            bucket_idx.to_string(),
             format!("{:.2}", cs.column("mean")?.f64()?.get(0).unwrap_or(0.0)),
             format!("{:.2}", cs.column("med")?.f64()?.get(0).unwrap_or(0.0)),
             format!("{:.2}", cs.column("p90")?.f64()?.get(0).unwrap_or(0.0)),
@@ -2064,7 +2484,9 @@ fn collect_stats_rows(
     if per_endpoint && df.column("endpoint").is_ok() {
         let rows = collect_per_endpoint_rows(df, run_time_secs)?;
         if !rows.is_empty() {
-            if !detail_rows.is_empty() { detail_rows.push(vec![]); }
+            if !detail_rows.is_empty() {
+                detail_rows.push(vec![]);
+            }
             detail_rows.extend(rows);
         }
     }
@@ -2074,32 +2496,53 @@ fn collect_stats_rows(
 
 /// Collect per-client statistics rows for Excel.
 fn collect_per_client_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<Vec<String>>> {
-    if df.column("client_id").is_err() { return Ok(vec![]); }
+    if df.column("client_id").is_err() {
+        return Ok(vec![]);
+    }
 
-    let cs = df.clone().lazy()
+    let cs = df
+        .clone()
+        .lazy()
         .group_by([col("client_id")])
         .agg([
             (col("duration_ns").mean() / lit(1000.0)).alias("mean"),
             (col("duration_ns").median() / lit(1000.0)).alias("med"),
-            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90"),
-            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95"),
-            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99"),
+            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p90"),
+            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p95"),
+            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p99"),
             (col("duration_ns").max() / lit(1000.0)).alias("max"),
             (col("bytes").mean() / lit(1024.0)).alias("avg"),
             (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops"),
-            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xp"),
+            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                / lit(run_time_secs))
+            .alias("xp"),
             col("op").count().alias("count"),
         ])
         .sort(["client_id"], SortMultipleOptions::default())
         .collect()?;
 
-    if cs.height() == 0 { return Ok(vec![]); }
+    if cs.height() == 0 {
+        return Ok(vec![]);
+    }
 
     let mut rows: Vec<Vec<String>> = vec![
         vec!["=== Per-Client Statistics ===".into()],
-        vec!["client_id".into(), "mean_lat_us".into(), "med._lat_us".into(),
-             "90%_lat_us".into(), "95%_lat_us".into(), "99%_lat_us".into(),
-             "max_lat_us".into(), "avg_obj_KB".into(), "ops_/_sec".into(), "xput_MBps".into(), "count".into()],
+        vec![
+            "client_id".into(),
+            "mean_lat_us".into(),
+            "med._lat_us".into(),
+            "90%_lat_us".into(),
+            "95%_lat_us".into(),
+            "99%_lat_us".into(),
+            "max_lat_us".into(),
+            "avg_obj_KB".into(),
+            "ops_/_sec".into(),
+            "xput_MBps".into(),
+            "count".into(),
+        ],
     ];
 
     let cid = cs.column("client_id")?.str()?;
@@ -2122,32 +2565,48 @@ fn collect_per_client_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<Vec
     // Per-op breakdowns
     for (op_name, ops_list) in [
         ("META", META_OPS.as_slice()),
-        ("GET",  ["GET"].as_slice()),
-        ("PUT",  ["PUT"].as_slice()),
+        ("GET", ["GET"].as_slice()),
+        ("PUT", ["PUT"].as_slice()),
     ] {
         let mut filt = lit(false);
-        for op in ops_list { filt = filt.or(col("op").eq(lit(*op))); }
+        for op in ops_list {
+            filt = filt.or(col("op").eq(lit(*op)));
+        }
 
-        let os = df.clone().lazy()
+        let os = df
+            .clone()
+            .lazy()
             .filter(filt)
             .group_by([col("client_id")])
             .agg([
                 (col("duration_ns").mean() / lit(1000.0)).alias("mean"),
                 (col("duration_ns").median() / lit(1000.0)).alias("med"),
-                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99"),
+                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                    .alias("p99"),
                 (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops"),
-                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xp"),
+                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                    / lit(run_time_secs))
+                .alias("xp"),
                 col("op").count().alias("count"),
             ])
             .sort(["client_id"], SortMultipleOptions::default())
             .collect()?;
 
-        if os.height() == 0 { continue; }
+        if os.height() == 0 {
+            continue;
+        }
 
         rows.push(vec![]);
         rows.push(vec![format!("--- {} Operations ---", op_name)]);
-        rows.push(vec!["client_id".into(), "mean_lat_us".into(), "med._lat_us".into(),
-                        "99%_lat_us".into(), "ops_/_sec".into(), "xput_MBps".into(), "count".into()]);
+        rows.push(vec![
+            "client_id".into(),
+            "mean_lat_us".into(),
+            "med._lat_us".into(),
+            "99%_lat_us".into(),
+            "ops_/_sec".into(),
+            "xput_MBps".into(),
+            "count".into(),
+        ]);
 
         let cid = os.column("client_id")?.str()?;
         for i in 0..os.height() {
@@ -2168,34 +2627,55 @@ fn collect_per_client_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<Vec
 
 /// Collect per-endpoint statistics rows for Excel.
 fn collect_per_endpoint_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<Vec<String>>> {
-    if df.column("endpoint").is_err() { return Ok(vec![]); }
+    if df.column("endpoint").is_err() {
+        return Ok(vec![]);
+    }
 
-    let es = df.clone().lazy()
+    let es = df
+        .clone()
+        .lazy()
         .filter(col("endpoint").is_not_null())
         .group_by([col("endpoint")])
         .agg([
             (col("duration_ns").mean() / lit(1000.0)).alias("mean"),
             (col("duration_ns").median() / lit(1000.0)).alias("med"),
-            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0)).alias("p90"),
-            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0)).alias("p95"),
-            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99"),
+            (col("duration_ns").quantile(lit(0.90), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p90"),
+            (col("duration_ns").quantile(lit(0.95), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p95"),
+            (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                .alias("p99"),
             (col("duration_ns").max() / lit(1000.0)).alias("max"),
             (col("bytes").mean() / lit(1024.0)).alias("avg"),
             (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops"),
-            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xp"),
+            ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                / lit(run_time_secs))
+            .alias("xp"),
             col("op").count().alias("count"),
         ])
         .filter(col("count").gt(lit(0u32)))
         .sort(["endpoint"], SortMultipleOptions::default())
         .collect()?;
 
-    if es.height() == 0 { return Ok(vec![]); }
+    if es.height() == 0 {
+        return Ok(vec![]);
+    }
 
     let mut rows: Vec<Vec<String>> = vec![
         vec!["=== Per-Endpoint Statistics ===".into()],
-        vec!["endpoint".into(), "mean_lat_us".into(), "med._lat_us".into(),
-             "90%_lat_us".into(), "95%_lat_us".into(), "99%_lat_us".into(),
-             "max_lat_us".into(), "avg_obj_KB".into(), "ops_/_sec".into(), "xput_MBps".into(), "count".into()],
+        vec![
+            "endpoint".into(),
+            "mean_lat_us".into(),
+            "med._lat_us".into(),
+            "90%_lat_us".into(),
+            "95%_lat_us".into(),
+            "99%_lat_us".into(),
+            "max_lat_us".into(),
+            "avg_obj_KB".into(),
+            "ops_/_sec".into(),
+            "xput_MBps".into(),
+            "count".into(),
+        ],
     ];
 
     let ep = es.column("endpoint")?.str()?;
@@ -2218,33 +2698,49 @@ fn collect_per_endpoint_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<V
     // Per-op breakdowns
     for (op_name, ops_list) in [
         ("META", META_OPS.as_slice()),
-        ("GET",  ["GET"].as_slice()),
-        ("PUT",  ["PUT"].as_slice()),
+        ("GET", ["GET"].as_slice()),
+        ("PUT", ["PUT"].as_slice()),
     ] {
         let mut filt = lit(false);
-        for op in ops_list { filt = filt.or(col("op").eq(lit(*op))); }
+        for op in ops_list {
+            filt = filt.or(col("op").eq(lit(*op)));
+        }
 
-        let os = df.clone().lazy()
+        let os = df
+            .clone()
+            .lazy()
             .filter(filt.and(col("endpoint").is_not_null()))
             .group_by([col("endpoint")])
             .agg([
                 (col("duration_ns").mean() / lit(1000.0)).alias("mean"),
                 (col("duration_ns").median() / lit(1000.0)).alias("med"),
-                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0)).alias("p99"),
+                (col("duration_ns").quantile(lit(0.99), QuantileMethod::Linear) / lit(1000.0))
+                    .alias("p99"),
                 (col("op").count().cast(DataType::Float64) / lit(run_time_secs)).alias("ops"),
-                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0)) / lit(run_time_secs)).alias("xp"),
+                ((col("bytes").sum().cast(DataType::Float64) / lit(1024.0 * 1024.0))
+                    / lit(run_time_secs))
+                .alias("xp"),
                 col("op").count().alias("count"),
             ])
             .filter(col("count").gt(lit(0u32)))
             .sort(["endpoint"], SortMultipleOptions::default())
             .collect()?;
 
-        if os.height() == 0 { continue; }
+        if os.height() == 0 {
+            continue;
+        }
 
         rows.push(vec![]);
         rows.push(vec![format!("--- {} Operations ---", op_name)]);
-        rows.push(vec!["endpoint".into(), "mean_lat_us".into(), "med._lat_us".into(),
-                        "99%_lat_us".into(), "ops_/_sec".into(), "xput_MBps".into(), "count".into()]);
+        rows.push(vec![
+            "endpoint".into(),
+            "mean_lat_us".into(),
+            "med._lat_us".into(),
+            "99%_lat_us".into(),
+            "ops_/_sec".into(),
+            "xput_MBps".into(),
+            "count".into(),
+        ]);
 
         let ep = os.column("endpoint")?.str()?;
         for i in 0..os.height() {
@@ -2380,14 +2876,22 @@ mod tests {
     #[test]
     fn test_derive_short_name_warp_bracket() {
         // Warp-style filename: everything from '[' onwards is stripped
-        assert_eq!(derive_short_name("warp-run[20260101]-abc.tsv.zst"), "warp-run");
+        assert_eq!(
+            derive_short_name("warp-run[20260101]-abc.tsv.zst"),
+            "warp-run"
+        );
     }
 
     #[test]
     fn test_derive_short_name_truncates_to_20() {
         // A base name longer than 20 chars must be truncated to at most 20
         let name = derive_short_name("this-is-a-very-long-filename-indeed.tsv.zst");
-        assert!(name.len() <= 20, "expected ≤20 chars, got {}: {:?}", name.len(), name);
+        assert!(
+            name.len() <= 20,
+            "expected ≤20 chars, got {}: {:?}",
+            name.len(),
+            name
+        );
     }
 
     // ── derive_excel_path ───────────────────────────────────────────────────
@@ -2401,10 +2905,8 @@ mod tests {
 
     #[test]
     fn test_derive_excel_path_multiple_files() {
-        let path = derive_excel_path(&[
-            "agent-1.tsv.zst".to_string(),
-            "agent-2.tsv.zst".to_string(),
-        ]);
+        let path =
+            derive_excel_path(&["agent-1.tsv.zst".to_string(), "agent-2.tsv.zst".to_string()]);
         assert_eq!(path, "polarwarp-results.xlsx");
     }
 
@@ -2425,7 +2927,11 @@ mod tests {
             name.len(),
             name
         );
-        assert!(name.ends_with("-Results"), "expected '-Results' suffix, got {:?}", name);
+        assert!(
+            name.ends_with("-Results"),
+            "expected '-Results' suffix, got {:?}",
+            name
+        );
     }
 
     // ── FileType enum ───────────────────────────────────────────────────────
@@ -2443,7 +2949,13 @@ mod tests {
     fn test_size_bucket_zero_bytes() {
         let df = df!["bytes" => [0i64]].unwrap();
         let result = add_size_buckets(df).unwrap();
-        let bucket = result.column("bytes_bucket").unwrap().str().unwrap().get(0).unwrap();
+        let bucket = result
+            .column("bytes_bucket")
+            .unwrap()
+            .str()
+            .unwrap()
+            .get(0)
+            .unwrap();
         assert_eq!(bucket, "zero");
     }
 
@@ -2468,15 +2980,15 @@ mod tests {
         let result = add_size_buckets(df).unwrap();
         let bc = result.column("bytes_bucket").unwrap().str().unwrap();
 
-        assert_eq!(bc.get(0).unwrap(), "1B-8KiB",       "1 byte");
-        assert_eq!(bc.get(1).unwrap(), "1B-8KiB",       "8191 bytes");
-        assert_eq!(bc.get(2).unwrap(), "8KiB-64KiB",    "8192 bytes");
-        assert_eq!(bc.get(3).unwrap(), "64KiB-512KiB",  "64 KiB");
-        assert_eq!(bc.get(4).unwrap(), "512KiB-4MiB",   "512 KiB");
-        assert_eq!(bc.get(5).unwrap(), "4MiB-32MiB",    "4 MiB");
-        assert_eq!(bc.get(6).unwrap(), "32MiB-256MiB",  "32 MiB");
-        assert_eq!(bc.get(7).unwrap(), "256MiB-2GiB",   "256 MiB");
-        assert_eq!(bc.get(8).unwrap(), ">2GiB",         "2 GiB");
+        assert_eq!(bc.get(0).unwrap(), "1B-8KiB", "1 byte");
+        assert_eq!(bc.get(1).unwrap(), "1B-8KiB", "8191 bytes");
+        assert_eq!(bc.get(2).unwrap(), "8KiB-64KiB", "8192 bytes");
+        assert_eq!(bc.get(3).unwrap(), "64KiB-512KiB", "64 KiB");
+        assert_eq!(bc.get(4).unwrap(), "512KiB-4MiB", "512 KiB");
+        assert_eq!(bc.get(5).unwrap(), "4MiB-32MiB", "4 MiB");
+        assert_eq!(bc.get(6).unwrap(), "32MiB-256MiB", "32 MiB");
+        assert_eq!(bc.get(7).unwrap(), "256MiB-2GiB", "256 MiB");
+        assert_eq!(bc.get(8).unwrap(), ">2GiB", "2 GiB");
     }
 
     #[test]
@@ -2489,14 +3001,15 @@ mod tests {
         .unwrap();
         let result = add_size_buckets(df).unwrap();
         let labels = result.column("bytes_bucket").unwrap().str().unwrap();
-        let nums   = result.column("bucket_num").unwrap().i32().unwrap();
+        let nums = result.column("bucket_num").unwrap().i32().unwrap();
 
         for i in 0..result.height() {
             let label = labels.get(i).unwrap();
-            let num   = nums.get(i).unwrap();
+            let num = nums.get(i).unwrap();
             assert_eq!(
                 label, BUCKET_LABELS[num as usize],
-                "row {}: bucket_num {} → label mismatch", i, num
+                "row {}: bucket_num {} → label mismatch",
+                i, num
             );
         }
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2112,3 +2112,242 @@ fn collect_per_endpoint_rows(df: &DataFrame, run_time_secs: f64) -> Result<Vec<V
 
     Ok(rows)
 }
+
+// ─────────────────────────────── Unit tests ──────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_skip_time ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_skip_time_seconds() {
+        let nanos = parse_skip_time("90s").unwrap();
+        assert_eq!(nanos, 90 * 1_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_skip_time_minutes() {
+        let nanos = parse_skip_time("5m").unwrap();
+        assert_eq!(nanos, 5 * 60 * 1_000_000_000);
+    }
+
+    #[test]
+    fn test_parse_skip_time_zero() {
+        let nanos = parse_skip_time("0s").unwrap();
+        assert_eq!(nanos, 0);
+    }
+
+    #[test]
+    fn test_parse_skip_time_invalid_unit() {
+        // "h" (hours) is not a recognised unit
+        assert!(parse_skip_time("2h").is_err());
+    }
+
+    #[test]
+    fn test_parse_skip_time_invalid_format() {
+        assert!(parse_skip_time("abc").is_err());
+        assert!(parse_skip_time("").is_err());
+    }
+
+    // ── format_with_commas ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_with_commas_zero() {
+        assert_eq!(format_with_commas(0.0), "0.00");
+    }
+
+    #[test]
+    fn test_format_with_commas_thousands() {
+        assert_eq!(format_with_commas(1_000.0), "1,000.00");
+    }
+
+    #[test]
+    fn test_format_with_commas_large() {
+        assert_eq!(format_with_commas(1_234_567.0), "1,234,567.00");
+    }
+
+    #[test]
+    fn test_format_with_commas_fractional() {
+        // 1024.75: integer part 1024 gets commas, fractional part is .75
+        assert_eq!(format_with_commas(1_024.75), "1,024.75");
+    }
+
+    // ── format_int_with_commas ──────────────────────────────────────────────
+
+    #[test]
+    fn test_format_int_with_commas_small() {
+        assert_eq!(format_int_with_commas(42), "42");
+    }
+
+    #[test]
+    fn test_format_int_with_commas_million() {
+        assert_eq!(format_int_with_commas(1_000_000), "1,000,000");
+    }
+
+    // ── format_duration_ns ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_duration_ns_zero() {
+        // 0 ns → 0 h, 0 m, 0.0 s  — seconds field uses {:09.6} = "00.000000"
+        assert_eq!(format_duration_ns(0), "0:00:00.000000");
+    }
+
+    #[test]
+    fn test_format_duration_ns_one_second() {
+        assert_eq!(format_duration_ns(1_000_000_000), "0:00:01.000000");
+    }
+
+    #[test]
+    fn test_format_duration_ns_one_minute() {
+        assert_eq!(format_duration_ns(60_000_000_000), "0:01:00.000000");
+    }
+
+    #[test]
+    fn test_format_duration_ns_one_hour() {
+        assert_eq!(format_duration_ns(3_600_000_000_000), "1:00:00.000000");
+    }
+
+    #[test]
+    fn test_format_duration_ns_90_seconds() {
+        // 90 s = 1 min 30 s
+        assert_eq!(format_duration_ns(90_000_000_000), "0:01:30.000000");
+    }
+
+    // ── derive_short_name ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_derive_short_name_tsv_zst() {
+        assert_eq!(derive_short_name("agent-1.tsv.zst"), "agent-1");
+    }
+
+    #[test]
+    fn test_derive_short_name_csv_no_zst() {
+        assert_eq!(derive_short_name("/tmp/results.csv"), "results");
+    }
+
+    #[test]
+    fn test_derive_short_name_warp_bracket() {
+        // Warp-style filename: everything from '[' onwards is stripped
+        assert_eq!(derive_short_name("warp-run[20260101]-abc.tsv.zst"), "warp-run");
+    }
+
+    #[test]
+    fn test_derive_short_name_truncates_to_20() {
+        // A base name longer than 20 chars must be truncated to at most 20
+        let name = derive_short_name("this-is-a-very-long-filename-indeed.tsv.zst");
+        assert!(name.len() <= 20, "expected ≤20 chars, got {}: {:?}", name.len(), name);
+    }
+
+    // ── derive_excel_path ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_derive_excel_path_single_file() {
+        // Single file with no directory component → same stem with .xlsx extension
+        let path = derive_excel_path(&["run.tsv.zst".to_string()]);
+        assert_eq!(path, "run.xlsx");
+    }
+
+    #[test]
+    fn test_derive_excel_path_multiple_files() {
+        let path = derive_excel_path(&[
+            "agent-1.tsv.zst".to_string(),
+            "agent-2.tsv.zst".to_string(),
+        ]);
+        assert_eq!(path, "polarwarp-results.xlsx");
+    }
+
+    // ── make_tab_name ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_make_tab_name_short() {
+        assert_eq!(make_tab_name("run", "Results"), "run-Results");
+    }
+
+    #[test]
+    fn test_make_tab_name_enforces_31_char_limit() {
+        // Excel worksheet names must be ≤ 31 characters
+        let name = make_tab_name("this-is-a-very-long-base-name-here", "Results");
+        assert!(
+            name.len() <= 31,
+            "expected ≤31 chars, got {}: {:?}",
+            name.len(),
+            name
+        );
+        assert!(name.ends_with("-Results"), "expected '-Results' suffix, got {:?}", name);
+    }
+
+    // ── FileType enum ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_file_type_equality() {
+        assert_eq!(FileType::Trace, FileType::Trace);
+        assert_eq!(FileType::Summary, FileType::Summary);
+        assert_ne!(FileType::Trace, FileType::Summary);
+    }
+
+    // ── add_size_buckets (core bucketing logic) ─────────────────────────────
+
+    #[test]
+    fn test_size_bucket_zero_bytes() {
+        let df = df!["bytes" => [0i64]].unwrap();
+        let result = add_size_buckets(df).unwrap();
+        let bucket = result.column("bytes_bucket").unwrap().str().unwrap().get(0).unwrap();
+        assert_eq!(bucket, "zero");
+    }
+
+    #[test]
+    fn test_size_bucket_boundaries() {
+        // One value per bucket, including each exact lower boundary
+        let df = df![
+            "bytes" => [
+                1i64,               // 1B-8KiB  (1 byte)
+                8 * 1024 - 1,       // 1B-8KiB  (8191 bytes, just below 8 KiB)
+                8 * 1024,           // 8KiB-64KiB  (8192 = BUCKET_8K)
+                64 * 1024,          // 64KiB-512KiB
+                512 * 1024,         // 512KiB-4MiB
+                4 * 1024 * 1024,    // 4MiB-32MiB
+                32 * 1024 * 1024,   // 32MiB-256MiB
+                256 * 1024 * 1024,  // 256MiB-2GiB
+                2i64 * 1024 * 1024 * 1024  // >2GiB
+            ]
+        ]
+        .unwrap();
+
+        let result = add_size_buckets(df).unwrap();
+        let bc = result.column("bytes_bucket").unwrap().str().unwrap();
+
+        assert_eq!(bc.get(0).unwrap(), "1B-8KiB",       "1 byte");
+        assert_eq!(bc.get(1).unwrap(), "1B-8KiB",       "8191 bytes");
+        assert_eq!(bc.get(2).unwrap(), "8KiB-64KiB",    "8192 bytes");
+        assert_eq!(bc.get(3).unwrap(), "64KiB-512KiB",  "64 KiB");
+        assert_eq!(bc.get(4).unwrap(), "512KiB-4MiB",   "512 KiB");
+        assert_eq!(bc.get(5).unwrap(), "4MiB-32MiB",    "4 MiB");
+        assert_eq!(bc.get(6).unwrap(), "32MiB-256MiB",  "32 MiB");
+        assert_eq!(bc.get(7).unwrap(), "256MiB-2GiB",   "256 MiB");
+        assert_eq!(bc.get(8).unwrap(), ">2GiB",         "2 GiB");
+    }
+
+    #[test]
+    fn test_size_bucket_num_matches_label() {
+        // bucket_num and bytes_bucket must be consistent for every row
+        let df = df![
+            "bytes" => [0i64, 1i64, 8192i64, 65536i64, 524288i64,
+                        4194304i64, 33554432i64, 268435456i64, 2147483648i64]
+        ]
+        .unwrap();
+        let result = add_size_buckets(df).unwrap();
+        let labels = result.column("bytes_bucket").unwrap().str().unwrap();
+        let nums   = result.column("bucket_num").unwrap().i32().unwrap();
+
+        for i in 0..result.height() {
+            let label = labels.get(i).unwrap();
+            let num   = nums.get(i).unwrap();
+            assert_eq!(
+                label, BUCKET_LABELS[num as usize],
+                "row {}: bucket_num {} → label mismatch", i, num
+            );
+        }
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Parser, ArgAction};
 use num_format::{Locale, ToFormattedString};
 use polars::prelude::*;
 use regex::Regex;
-use rust_xlsxwriter::{Format, Workbook};
+use rust_xlsxwriter::{Chart, ChartLegendPosition, ChartType, Format, Workbook};
 
 /// Rows for one Excel results tab and one detail tab: (results_rows, detail_rows)
 type ExcelTabRows = (Vec<Vec<String>>, Vec<Vec<String>>);
@@ -279,8 +279,9 @@ fn main() -> Result<()> {
     // Excel: per-file collected rows (main_rows, detail_rows, file_path)
     let mut file_excel_data: Vec<FileExcelEntry> = Vec::new();
 
-    // Summary-file Excel rows collected separately (one entry per file)
-    let mut summary_excel_data: Vec<(Vec<Vec<String>>, String)> = Vec::new();
+    // Summary-file Excel rows collected separately (one entry per file):
+    // (stats_rows, raw_df_for_charts, file_path)
+    let mut summary_excel_data: Vec<(Vec<Vec<String>>, DataFrame, String)> = Vec::new();
     let mut any_summary_file = false;
     let mut any_trace_file = false;
 
@@ -300,7 +301,7 @@ fn main() -> Result<()> {
                 let (df, _, _) = process_summary_file(file_path)?;
                 if excel_path.is_some() {
                     let rows = collect_summary_excel_rows(&df)?;
-                    summary_excel_data.push((rows, file_path.clone()));
+                    summary_excel_data.push((rows, df.clone(), file_path.clone()));
                 }
                 let elapsed = start.elapsed();
                 println!("Processed file in {:.2?}", elapsed);
@@ -491,15 +492,17 @@ fn main() -> Result<()> {
             }
         }
 
-        // Add one tab per summary file
-        for (rows, fp) in &summary_excel_data {
+        // Add one tab per summary file (stats) and collect chart tab data
+        let mut chart_tab_data: Vec<(DataFrame, String)> = Vec::new();
+        for (rows, df, fp) in &summary_excel_data {
             let short = derive_short_name(fp);
             let tab_name = make_tab_name(&short, "Summary");
             tabs.push((tab_name, rows.clone()));
+            chart_tab_data.push((df.clone(), make_tab_name(&short, "Charts")));
         }
 
-        if !tabs.is_empty() {
-            write_excel_workbook(path, &tabs)?;
+        if !tabs.is_empty() || !chart_tab_data.is_empty() {
+            write_excel_workbook_with_chart_tabs(path, &tabs, &chart_tab_data)?;
             println!("\nExcel file written: {}", path);
         }
     }
@@ -1704,15 +1707,20 @@ fn make_tab_name(base: &str, suffix: &str) -> String {
     }
 }
 
-/// Write an Excel workbook where each `(tab_name, rows)` element becomes one worksheet.
-/// The first row of each `rows` slice is treated as the header (bold).
-/// Numeric cell values are stored as numbers; others as strings.
-fn write_excel_workbook(path: &str, tabs: &[(String, Vec<Vec<String>>)]) -> Result<()> {
+/// Write an Excel workbook that includes both regular string-based tabs and
+/// time-series chart tabs for summary files.  Replaces a bare
+/// `write_excel_workbook` call when there are summary files to chart.
+fn write_excel_workbook_with_chart_tabs(
+    path: &str,
+    tabs: &[(String, Vec<Vec<String>>)],
+    chart_tabs: &[(DataFrame, String)],
+) -> Result<()> {
     let mut workbook = Workbook::new();
-    let header_fmt = Format::new().set_bold().set_font_name("Aptos");
-    let data_fmt   = Format::new().set_font_name("Aptos");
+    let header_fmt  = Format::new().set_bold().set_font_name("Aptos");
+    let data_fmt    = Format::new().set_font_name("Aptos");
     let section_fmt = Format::new().set_bold().set_font_name("Aptos").set_font_size(11.0);
 
+    // Write regular (string-based) tabs — identical to write_excel_workbook
     for (tab_name, rows) in tabs {
         if rows.is_empty() {
             continue;
@@ -1721,7 +1729,6 @@ fn write_excel_workbook(path: &str, tabs: &[(String, Vec<Vec<String>>)]) -> Resu
         ws.set_name(tab_name)?;
 
         for (row_idx, row) in rows.iter().enumerate() {
-            // A row with one cell that starts with "===" or "---" is a section header
             let is_section = row.len() == 1 &&
                 (row[0].starts_with("===") || row[0].starts_with("---"));
 
@@ -1739,7 +1746,6 @@ fn write_excel_workbook(path: &str, tabs: &[(String, Vec<Vec<String>>)]) -> Resu
             }
         }
 
-        // Set column widths based on max content length in each column
         if let Some(header) = rows.first() {
             for col_idx in 0..header.len() {
                 let max_len = rows.iter()
@@ -1751,7 +1757,151 @@ fn write_excel_workbook(path: &str, tabs: &[(String, Vec<Vec<String>>)]) -> Resu
         }
     }
 
+    // Write time-series chart tabs for summary files
+    for (df, tab_name) in chart_tabs {
+        write_summary_chart_tab(&mut workbook, df, tab_name)?;
+    }
+
     workbook.save(path).with_context(|| format!("Failed to save Excel file: {}", path))?;
+    Ok(())
+}
+
+/// Write a worksheet with per-second time-series data and two embedded line charts:
+///   1. Operations/sec over Time (one series per non-TOTAL op)
+///   2. Throughput MiB/s over Time (GET and PUT only — META has no byte payload)
+///
+/// Column layout: [seconds | <op>_ops … | <op>_MBps …]
+/// Charts are inserted below the data table, side by side.
+fn write_summary_chart_tab(
+    workbook: &mut Workbook,
+    df: &DataFrame,
+    tab_name: &str,
+) -> Result<()> {
+    // Filter TOTAL rows; sort by time then op for deterministic ordering
+    let df_filt = df.clone().lazy()
+        .filter(col("op").neq(lit("TOTAL")))
+        .sort(["start_ns", "op"], SortMultipleOptions::default())
+        .collect()?;
+
+    if df_filt.height() == 0 {
+        return Ok(());
+    }
+
+    let op_col    = df_filt.column("op")?.str()?;
+    let start_col = df_filt.column("start_ns")?.i64()?;
+    let bps_col   = df_filt.column("bps")?.f64()?;
+    let ops_col   = df_filt.column("ops_per_sec")?.f64()?;
+
+    let min_ns = start_col.min().unwrap_or(0);
+
+    // Collect unique ops (sorted) and unique second offsets (sorted)
+    let mut ops_set:  std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut secs_set: std::collections::HashSet<i64>    = std::collections::HashSet::new();
+    for i in 0..df_filt.height() {
+        ops_set.insert(op_col.get(i).unwrap_or("").to_string());
+        secs_set.insert((start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000);
+    }
+    let mut all_ops:  Vec<String> = ops_set.into_iter().collect();
+    all_ops.sort();
+    let mut all_secs: Vec<i64> = secs_set.into_iter().collect();
+    all_secs.sort();
+
+    let n_rows = all_secs.len();
+    let n_ops  = all_ops.len();
+
+    // Build per-(op, seconds) lookup → (ops_per_sec, MBps)
+    let mut lookup: std::collections::HashMap<(String, i64), (f64, f64)> =
+        std::collections::HashMap::new();
+    for i in 0..df_filt.height() {
+        let op   = op_col.get(i).unwrap_or("").to_string();
+        let secs = (start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000;
+        let ops  = ops_col.get(i).unwrap_or(0.0);
+        let mbps = bps_col.get(i).unwrap_or(0.0) / 1_048_576.0;
+        lookup.insert((op, secs), (ops, mbps));
+    }
+
+    // ops for throughput chart: GET and PUT only (META has no byte payload)
+    let bw_ops: Vec<&String> = all_ops.iter()
+        .filter(|o| o.as_str() == "GET" || o.as_str() == "PUT")
+        .collect();
+
+    // ── Write worksheet ───────────────────────────────────────────────────────
+    let ws = workbook.add_worksheet();
+    ws.set_name(tab_name)?;
+
+    let header_fmt = Format::new().set_bold().set_font_name("Aptos");
+    let data_fmt   = Format::new().set_font_name("Aptos");
+
+    // Header row: seconds | <op>_ops … | <op>_MBps …
+    ws.write_string_with_format(0, 0, "seconds", &header_fmt)?;
+    for (oi, op) in all_ops.iter().enumerate() {
+        ws.write_string_with_format(0, (oi + 1) as u16, &format!("{}_ops", op), &header_fmt)?;
+    }
+    for (bi, op) in bw_ops.iter().enumerate() {
+        ws.write_string_with_format(0, (n_ops + 1 + bi) as u16, &format!("{}_MBps", op), &header_fmt)?;
+    }
+
+    // Data rows
+    for (ri, &secs) in all_secs.iter().enumerate() {
+        let row = (ri + 1) as u32;
+        ws.write_number_with_format(row, 0, secs as f64, &data_fmt)?;
+        for (oi, op) in all_ops.iter().enumerate() {
+            if let Some(&(ops, _)) = lookup.get(&(op.clone(), secs)) {
+                ws.write_number_with_format(row, (oi + 1) as u16, ops, &data_fmt)?;
+            }
+        }
+        for (bi, op) in bw_ops.iter().enumerate() {
+            if let Some(&(_, mbps)) = lookup.get(&((*op).clone(), secs)) {
+                ws.write_number_with_format(row, (n_ops + 1 + bi) as u16, mbps, &data_fmt)?;
+            }
+        }
+    }
+
+    // Set column widths
+    let n_cols = 1 + n_ops + bw_ops.len();
+    for ci in 0..n_cols {
+        ws.set_column_width(ci as u16, 13.0)?;
+    }
+
+    // ── Charts ────────────────────────────────────────────────────────────────
+    let chart_row = (n_rows + 3) as u32;
+
+    // Chart 1: ops/sec over time
+    if n_ops > 0 {
+        let mut chart_ops = Chart::new(ChartType::Line);
+        chart_ops.title().set_name("Operations/sec over Time");
+        chart_ops.x_axis().set_name("Seconds");
+        chart_ops.y_axis().set_name("ops/sec");
+        chart_ops.legend().set_position(ChartLegendPosition::Bottom);
+
+        for (oi, op) in all_ops.iter().enumerate() {
+            let data_col = (oi + 1) as u16;
+            chart_ops.add_series()
+                .set_name(op.as_str())
+                .set_categories((tab_name, 1, 0, n_rows as u32, 0))
+                .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
+        }
+        ws.insert_chart(chart_row, 0, &chart_ops)?;
+    }
+
+    // Chart 2: throughput (MiB/s) — GET and PUT only
+    if !bw_ops.is_empty() {
+        let mut chart_bw = Chart::new(ChartType::Line);
+        chart_bw.title().set_name("Throughput (MiB/s) over Time");
+        chart_bw.x_axis().set_name("Seconds");
+        chart_bw.y_axis().set_name("MiB/s");
+        chart_bw.legend().set_position(ChartLegendPosition::Bottom);
+
+        for (bi, op) in bw_ops.iter().enumerate() {
+            let data_col = (n_ops + 1 + bi) as u16;
+            chart_bw.add_series()
+                .set_name(op.as_str())
+                .set_categories((tab_name, 1, 0, n_rows as u32, 0))
+                .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
+        }
+        ws.insert_chart(chart_row, 8, &chart_bw)?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION

# Summary file parsing and time-series charts

---
**Title:** `v0.2.0: summary file parsing, time-series charts, and lint cleanup`
---

**Description:**

This PR delivers two feature releases and full lint/format compliance across both implementations.

---

### v0.1.7 — Summary file parsing

- **Auto-detection of `.summary.tsv.zst` files** alongside existing trace files — file type is determined from header columns (`bps`/`ops_per_sec` → summary; `duration_ns` → trace)
- **Per-op throughput variability statistics** reported for summary files: mean, p50, p90, p99, min, max, stdev (MBps) and mean/p50/p99 ops/sec
- **Excel export** (`--excel`): summary files produce a dedicated `{name}-Summary` statistics tab
- **Unit tests:** Rust 28 passing, Python 44 passing

---

### v0.2.0 — Time-series performance charts

When `--excel` is used with a summary file, a `{name}-Charts` tab is now generated alongside the `{name}-Summary` tab. The Charts tab contains:

| Chart | Series | X-axis |
|-------|--------|--------|
| Operations/sec over Time | GET, PUT, META | Seconds from start |
| Throughput (MiB/s) over Time | GET, PUT only¹ | Seconds from start |

The underlying per-second pivot table is also written above the charts for further analysis.

¹ META is excluded from the throughput chart — metadata operations carry no meaningful byte payload.

---

### Code quality

- **Rust:** `cargo fmt` (full reformat to rustfmt standard), `cargo clippy` (0 warnings)
- **Python:** `ruff format` + `ruff check` (0 issues), `pylint` **10.00/10**
  - Fixed genuine issues: `cell-var-from-loop` (5 closures capturing loop variables — fixed with default-argument capture), `inconsistent-return-statements`, `no-else-return` (2×), reimported module
  - Added `[tool.pylint]` and `[tool.ruff]` config to pyproject.toml; `pylint` and `ruff` added as dev dependencies
- **All tests passing:** Rust 28/28, Python 44/44

---

### Documentation

- Version badges updated to 0.2.0 across all READMEs
- `{name}-Charts` tab documented in root README, `rust/README.md`, `python/README.md`, and `rust/MANUAL.md`
- MANUAL.md workbook structure table and file formats section updated to cover summary files
- "Time-window analysis" removed from Future Enhancements (now shipped) 
