### PR TITLE
Feat/excel scatter autoscale

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,47 @@ Both implementations (Rust `polarwarp-rs` and Python `polars-warp`) track the sa
 
 ---
 
+## [0.2.1] - 2026-05-16
+
+### Changed
+
+- **XY scatter charts** (Rust and Python) — The `{name}-Charts` Excel tab now uses XY scatter
+  charts with straight lines and markers instead of plain line charts. Markers are sized at 4pt
+  (roughly half the Excel default) so they sit just above the connecting line without dominating.
+
+- **Auto-scaling throughput unit** (Rust and Python) — The throughput chart Y-axis and column
+  headers now auto-select the unit based on peak bandwidth in the dataset:
+
+  | Peak `bps` | Unit shown | Divisor |
+  |-----------|-----------|---------|
+  | ≥ 1 GB/s | GB/s | ÷ 1 000 000 000 |
+  | < 1 GB/s | MB/s | ÷ 1 000 000 |
+
+- **Auto-scaling ops/sec unit** (Rust and Python) — The I/O rate chart Y-axis and column
+  headers similarly auto-select between `Kops/s` (≥ 1 000 ops/s) and `ops/s` (< 1 000 ops/s).
+
+- **Raw per-second rows in Summary tab** (Rust and Python) — The `{name}-Summary` Excel tab
+  now contains the raw per-second rows from the source file (`op`, `start`, `end`, throughput,
+  `ops_per_sec`, `errors`), sorted by start time, rather than aggregate statistics. The aggregate
+  statistics view is still available in the terminal output.
+
+- **Chart tab column layout** — The Charts tab data columns are now organised as
+  `{op}_time_s`, `{op}_{unit}`, `{op}_{ops_unit}` triplets (one triplet per op type),
+  with TOTAL and zero-throughput ops excluded. Both the throughput and I/O-rate charts
+  share the same per-op elapsed-time column as their X axis.
+
+- **Documentation** — `README.md`, `rust/README.md`, and `rust/MANUAL.md` updated to
+  clearly describe the three Excel input modes (trace only, summary only, both together)
+  and the correct output tab contents.
+
+### Fixed
+
+- Rust: removed redundant `as u32` cast flagged by `cargo clippy`
+- Rust: applied `cargo fmt` formatting to three locations in `main.rs`
+- Python: applied `ruff format` reformat pass
+
+---
+
 ## [0.2.0] - 2026-05-15
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolarWarp
 
-[![Version](https://img.shields.io/badge/version-0.2.0-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
+[![Version](https://img.shields.io/badge/version-0.2.1-brightgreen.svg)](https://github.com/russfellows/polarWarp/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](python/)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](rust/)
@@ -228,9 +228,24 @@ For summary files, PolarWarp reports throughput variability statistics across se
    TOTAL    120   2,048.00   2,032.15   2,350.40   2,478.20   1,800.00   2,520.00        N/A     512.00     508.04     619.55             0
 ```
 
-With `--excel`, summary files produce two dedicated tabs in the workbook:
-- **`{name}-Summary`** — aggregate throughput statistics (mean, p50, p90, p99, min, max, stdev) per op type
-- **`{name}-Charts`** — per-second time-series data with two embedded line charts: ops/sec over time (all op types) and throughput MiB/s over time (GET + PUT)
+With `--excel`, there are three usage modes:
+
+```bash
+# Trace file only → Results + Detail tabs (latency, throughput, op counts)
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst
+
+# Summary file only → Summary + Charts tabs
+polarwarp-rs --excel=report.xlsx run.summary.tsv.zst
+
+# Both together → all four tabs in one workbook (recommended)
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst run.summary.tsv.zst
+```
+
+The trace and summary files for a given warp run share the same base filename, so passing both is straightforward.
+
+Summary file Excel tabs:
+- **`{name}-Summary`** — raw per-second rows from the file: op, start timestamp, end timestamp, GBps, ops/sec, errors
+- **`{name}-Charts`** — two XY scatter charts (Throughput GB/s and I/O Rate ops/sec vs elapsed time), one series per op type (GET, PUT, etc.; TOTAL excluded)
 
 ## Related Projects
 

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -662,12 +662,12 @@ def write_polarwarp_excel(
             chart_ops.set_y_axis({"name": ops_unit})
             chart_ops.set_legend({"position": "bottom"})
 
-            # Place both charts below the data, side by side
-            chart_row = n_rows + 3
+            # Place both charts to the right of the data, starting at row 1
+            n_data_cols = len(ts_pd.columns)
             if any(f"{op}_{bw_col_suffix}" in cols for op in ops_list):
-                ws.insert_chart(chart_row, 0, chart_bw)
+                ws.insert_chart(1, n_data_cols + 1, chart_bw)
             if any(f"{op}_{ops_col_suffix}" in cols for op in ops_list):
-                ws.insert_chart(chart_row, 8, chart_ops)
+                ws.insert_chart(1, n_data_cols + 9, chart_ops)
 
         # Pre-compute unique short names to avoid worksheet name collisions when
         # multiple files share the same prefix after truncation to 20 characters.

--- a/python/polarwarp.py
+++ b/python/polarwarp.py
@@ -76,9 +76,7 @@ def compute_per_client_stats(df, run_time_secs):
                 (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                 (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                 (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
-                    "xput_MBps"
-                ),
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
                 pl.count("op").alias("count"),
             ]
         )
@@ -128,9 +126,7 @@ def compute_per_client_stats(df, run_time_secs):
                     (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
                     (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
                     (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
-                        "xput_MBps"
-                    ),
+                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
                     pl.count("op").alias("count"),
                 ]
             )
@@ -148,9 +144,7 @@ def compute_per_client_stats(df, run_time_secs):
             "count",
         ]:
             if column in op_client_stats_pd:
-                op_client_stats_pd[column] = op_client_stats_pd[column].map(
-                    format_with_commas
-                )
+                op_client_stats_pd[column] = op_client_stats_pd[column].map(format_with_commas)
 
         print(f"\n{op_type} Operations:")
         print(op_client_stats_pd.to_string(index=False))
@@ -168,9 +162,7 @@ def compute_per_endpoint_stats(df, run_time_secs):
         print("\nendpoint column not found, skipping per-endpoint statistics.")
         return None
 
-    endpoints = (
-        df.select(pl.col("endpoint").drop_nulls().unique()).to_series().to_list()
-    )
+    endpoints = df.select(pl.col("endpoint").drop_nulls().unique()).to_series().to_list()
 
     if len(endpoints) <= 1:
         print("\nOnly one endpoint detected, skipping per-endpoint statistics.")
@@ -192,9 +184,7 @@ def compute_per_endpoint_stats(df, run_time_secs):
                 (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                 (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                 (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
-                    "xput_MBps"
-                ),
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
                 pl.count("op").alias("count"),
             ]
         )
@@ -217,9 +207,7 @@ def compute_per_endpoint_stats(df, run_time_secs):
     ]
     for column in columns_to_format:
         if column in endpoint_stats_pd:
-            endpoint_stats_pd[column] = endpoint_stats_pd[column].map(
-                format_with_commas
-            )
+            endpoint_stats_pd[column] = endpoint_stats_pd[column].map(format_with_commas)
 
     print(endpoint_stats_pd.to_string(index=False))
 
@@ -244,9 +232,7 @@ def compute_per_endpoint_stats(df, run_time_secs):
                     (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
                     (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
                     (pl.count("op") / run_time_secs).alias("ops_/_sec"),
-                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
-                        "xput_MBps"
-                    ),
+                    ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
                     pl.count("op").alias("count"),
                 ]
             )
@@ -313,13 +299,7 @@ def write_polarwarp_excel(
     def _short(fp):
         n = os.path.basename(fp)
         n = n.removesuffix(".zst")
-        n = (
-            n.removesuffix(".csv")
-            if n.endswith(".csv")
-            else n.removesuffix(".tsv")
-            if n.endswith(".tsv")
-            else n
-        )
+        n = n.removesuffix(".csv") if n.endswith(".csv") else n.removesuffix(".tsv") if n.endswith(".tsv") else n
         bi = n.find("[")
         if bi >= 0:
             n = n[:bi]
@@ -368,21 +348,11 @@ def write_polarwarp_excel(
             agg.append(pl.col("thread").n_unique().alias("max_threads"))
         result = df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(agg)
         result = (
-            result.with_columns(
-                pl.col("op")
-                .map_elements(
-                    lambda op: op_map.get(op, run_secs), return_dtype=pl.Float64
-                )
-                .alias("runtime_s")
-            )
+            result.with_columns(pl.col("op").map_elements(lambda op: op_map.get(op, run_secs), return_dtype=pl.Float64).alias("runtime_s"))
             .with_columns(
                 [
-                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias(
-                        "ops_/_sec"
-                    ),
-                    (pl.col("bytes_sum") / (1024 * 1024) / pl.col("runtime_s")).alias(
-                        "xput_MBps"
-                    ),
+                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
+                    (pl.col("bytes_sum") / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
                 ]
             )
             .drop(["bytes_sum"])
@@ -423,10 +393,7 @@ def write_polarwarp_excel(
                     (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                     (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                     (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-                    (
-                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
-                        / run_secs
-                    ).alias("xput_MBps"),
+                    ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
                     pl.count("op").alias("count"),
                 ]
             )
@@ -451,10 +418,7 @@ def write_polarwarp_excel(
                     (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                     (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                     (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-                    (
-                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
-                        / run_secs
-                    ).alias("xput_MBps"),
+                    ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
                     pl.count("op").alias("count"),
                 ]
             )
@@ -482,10 +446,7 @@ def write_polarwarp_excel(
                     (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
                     (pl.col("duration_ns").quantile(0.99) / 1000).alias("99%_lat_us"),
                     (pl.count("op").cast(pl.Float64) / run_secs).alias("ops_/_sec"),
-                    (
-                        (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024))
-                        / run_secs
-                    ).alias("xput_MBps"),
+                    ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / run_secs).alias("xput_MBps"),
                     pl.count("op").alias("count"),
                 ]
             )
@@ -571,73 +532,82 @@ def write_polarwarp_excel(
         def _build_timeseries_pd(sdf):
             """Build wide-format time-series data from a summary DataFrame.
 
-            Filters TOTAL rows, parses start timestamps, computes seconds-from-start,
-            and pivots so each op type becomes its own ops_per_sec and MBps columns.
+            Filters TOTAL rows and zero-throughput ops, parses start timestamps,
+            computes elapsed seconds from run start, and pivots so each op type
+            becomes its own GBps and ops_s columns.
 
             Returns (ts_pd, ops_list):
-              - ts_pd:    pandas DataFrame with columns [seconds, <op>_ops…, <op>_MBps…]
-              - ops_list: sorted list of non-TOTAL op names present in the data
+              - ts_pd:    pandas DataFrame with columns [elapsed_s, <op>_GBps, <op>_ops_s, …]
+              - ops_list: sorted list of non-TOTAL op names with non-zero throughput
             """
-            df_filt = sdf.filter(pl.col("op") != "TOTAL")
+            df_filt = sdf.filter((pl.col("op") != "TOTAL") & (pl.col("bps") > 0))
             if df_filt.height == 0:
                 return None, []
 
             # Parse ISO-8601 start strings to UTC datetimes, then compute
-            # seconds-from-first-interval as an integer offset.
-            df_filt = df_filt.with_columns(
-                pl.col("start")
-                .str.to_datetime(strict=False, time_unit="us", time_zone="UTC")
-                .alias("start_dt")
-            )
+            # elapsed seconds from the first interval.
+            df_filt = df_filt.with_columns(pl.col("start").str.to_datetime(strict=False, time_unit="us", time_zone="UTC").alias("start_dt"))
             min_start = df_filt.select(pl.col("start_dt").min()).item()
             df_filt = df_filt.with_columns(
                 [
-                    (
-                        (pl.col("start_dt") - min_start).dt.total_microseconds()
-                        / 1_000_000.0
-                    )
-                    .round(0)
-                    .cast(pl.Int64)
-                    .alias("seconds"),
-                    (pl.col("bps") / 1_048_576.0).alias("MBps"),
+                    ((pl.col("start_dt") - min_start).dt.total_microseconds() / 1_000_000.0).round(1).cast(pl.Float64).alias("elapsed_s"),
                 ]
             )
 
-            ops_list = sorted(
-                df_filt.select(pl.col("op").unique()).to_series().to_list()
+            # Auto-scale throughput unit based on peak bps
+            max_bps = df_filt.select(pl.col("bps").max()).item() or 0.0
+            if max_bps >= 1_000_000_000.0:
+                bw_divisor = 1_000_000_000.0
+                bw_unit = "GB/s"
+            else:
+                bw_divisor = 1_000_000.0
+                bw_unit = "MB/s"
+            bw_col_suffix = bw_unit.replace("/", "p")  # "GBps" or "MBps"
+
+            # Auto-scale ops unit based on peak ops/sec
+            max_ops = df_filt.select(pl.col("ops_per_sec").max()).item() or 0.0
+            if max_ops >= 1_000.0:
+                ops_divisor = 1_000.0
+                ops_unit = "Kops/s"
+            else:
+                ops_divisor = 1.0
+                ops_unit = "ops/s"
+            ops_col_suffix = ops_unit.replace("/", "_")  # "Kops_s" or "ops_s"
+
+            df_filt = df_filt.with_columns(
+                [
+                    (pl.col("bps") / bw_divisor).alias("bw_tmp"),
+                    (pl.col("ops_per_sec") / ops_divisor).alias("ops_tmp"),
+                ]
             )
 
-            # Pivot ops_per_sec and MBps so each op becomes a column.
+            ops_list = sorted(df_filt.select(pl.col("op").unique()).to_series().to_list())
+
+            # Pivot ops_per_sec and GBps so each op becomes a column.
             ops_pivot = df_filt.pivot(
                 on="op",
-                index="seconds",
-                values="ops_per_sec",
+                index="elapsed_s",
+                values="ops_tmp",
                 aggregate_function="mean",
             )
-            ops_pivot = ops_pivot.rename(
-                {op: f"{op}_ops" for op in ops_list if op in ops_pivot.columns}
-            )
+            ops_pivot = ops_pivot.rename({op: f"{op}_{ops_col_suffix}" for op in ops_list if op in ops_pivot.columns})
 
-            bw_pivot = df_filt.pivot(
-                on="op", index="seconds", values="MBps", aggregate_function="mean"
-            )
-            bw_pivot = bw_pivot.rename(
-                {op: f"{op}_MBps" for op in ops_list if op in bw_pivot.columns}
-            )
+            bw_pivot = df_filt.pivot(on="op", index="elapsed_s", values="bw_tmp", aggregate_function="mean")
+            bw_pivot = bw_pivot.rename({op: f"{op}_{bw_col_suffix}" for op in ops_list if op in bw_pivot.columns})
 
-            ts_df = ops_pivot.join(
-                bw_pivot, on="seconds", how="full", coalesce=True
-            ).sort("seconds")
-            return ts_df.to_pandas(), ops_list
+            ts_df = ops_pivot.join(bw_pivot, on="elapsed_s", how="full", coalesce=True).sort("elapsed_s")
+            return ts_df.to_pandas(), ops_list, bw_unit, ops_unit
 
         def _write_summary_chart_tab(wb, sdf, chart_tab_name):
-            """Write a time-series data tab with ops/sec and throughput line charts.
+            """Write a time-series data tab with XY scatter charts.
 
-            Produces two side-by-side line charts below the pivot data table:
-              1. Operations/sec over Time (GET, PUT, META series)
-              2. Throughput MiB/s over Time (GET, PUT only — META has no bandwidth)
+            Produces two side-by-side scatter charts (straight lines + markers)
+            below the pivot data table:
+              1. Throughput (GB/s) over Time
+              2. I/O Rate (ops/sec) over Time
+            TOTAL and zero-throughput ops are excluded.
             """
-            ts_pd, ops_list = _build_timeseries_pd(sdf)
+            ts_pd, ops_list, bw_unit, ops_unit = _build_timeseries_pd(sdf)
             if ts_pd is None or ts_pd.empty:
                 return
 
@@ -647,31 +617,17 @@ def write_polarwarp_excel(
             # Write pivot data (header + rows) starting at row 0
             _write_df(ws, ts_pd, startrow=0)
 
-            cols = list(ts_pd.columns)  # ['seconds', 'GET_ops', …, 'GET_MBps', …]
-            sec_ci = cols.index("seconds")
+            cols = list(ts_pd.columns)
+            sec_ci = cols.index("elapsed_s")
+            bw_col_suffix = bw_unit.replace("/", "p")  # "GBps" or "MBps"
+            ops_col_suffix = ops_unit.replace("/", "_")  # "Kops_s" or "ops_s"
 
-            # ── Chart 1: ops/sec over time ──────────────────────────────────────
-            chart_ops = wb.add_chart({"type": "line"})
+            marker = {"type": "circle", "size": 4}
+
+            # ── Chart 1: Throughput (GB/s) over time ───────────────────────────
+            chart_bw = wb.add_chart({"type": "scatter", "subtype": "straight_with_markers"})
             for op in ops_list:
-                col_name = f"{op}_ops"
-                if col_name in cols:
-                    ci = cols.index(col_name)
-                    chart_ops.add_series(
-                        {
-                            "name": op,
-                            "categories": [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
-                            "values": [chart_tab_name, 1, ci, n_rows, ci],
-                        }
-                    )
-            chart_ops.set_title({"name": "Operations/sec over Time"})
-            chart_ops.set_x_axis({"name": "Seconds"})
-            chart_ops.set_y_axis({"name": "ops/sec"})
-            chart_ops.set_legend({"position": "bottom"})
-
-            # ── Chart 2: throughput (MiB/s) — GET and PUT only ─────────────────
-            chart_bw = wb.add_chart({"type": "line"})
-            for op in (o for o in ops_list if o in ("GET", "PUT")):
-                col_name = f"{op}_MBps"
+                col_name = f"{op}_{bw_col_suffix}"
                 if col_name in cols:
                     ci = cols.index(col_name)
                     chart_bw.add_series(
@@ -679,19 +635,39 @@ def write_polarwarp_excel(
                             "name": op,
                             "categories": [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
                             "values": [chart_tab_name, 1, ci, n_rows, ci],
+                            "marker": marker,
                         }
                     )
-            chart_bw.set_title({"name": "Throughput (MiB/s) over Time"})
-            chart_bw.set_x_axis({"name": "Seconds"})
-            chart_bw.set_y_axis({"name": "MiB/s"})
+            chart_bw.set_title({"name": f"Throughput ({bw_unit}) over Time"})
+            chart_bw.set_x_axis({"name": "Elapsed Time (s)"})
+            chart_bw.set_y_axis({"name": f"Throughput ({bw_unit})"})
             chart_bw.set_legend({"position": "bottom"})
+
+            # ── Chart 2: I/O Rate (ops/sec) over time ──────────────────────────
+            chart_ops = wb.add_chart({"type": "scatter", "subtype": "straight_with_markers"})
+            for op in ops_list:
+                col_name = f"{op}_{ops_col_suffix}"
+                if col_name in cols:
+                    ci = cols.index(col_name)
+                    chart_ops.add_series(
+                        {
+                            "name": op,
+                            "categories": [chart_tab_name, 1, sec_ci, n_rows, sec_ci],
+                            "values": [chart_tab_name, 1, ci, n_rows, ci],
+                            "marker": marker,
+                        }
+                    )
+            chart_ops.set_title({"name": f"I/O Rate ({ops_unit}) over Time"})
+            chart_ops.set_x_axis({"name": "Elapsed Time (s)"})
+            chart_ops.set_y_axis({"name": ops_unit})
+            chart_ops.set_legend({"position": "bottom"})
 
             # Place both charts below the data, side by side
             chart_row = n_rows + 3
-            if any(f"{op}_ops" in cols for op in ops_list):
-                ws.insert_chart(chart_row, 0, chart_ops)
-            if any(f"{op}_MBps" in cols for op in ("GET", "PUT")):
-                ws.insert_chart(chart_row, 8, chart_bw)
+            if any(f"{op}_{bw_col_suffix}" in cols for op in ops_list):
+                ws.insert_chart(chart_row, 0, chart_bw)
+            if any(f"{op}_{ops_col_suffix}" in cols for op in ops_list):
+                ws.insert_chart(chart_row, 8, chart_ops)
 
         # Pre-compute unique short names to avoid worksheet name collisions when
         # multiple files share the same prefix after truncation to 20 characters.
@@ -764,9 +740,7 @@ def write_polarwarp_excel(
         print(f"\nExcel file written: {excel_path}")
 
     except Exception as e:
-        print(
-            f"Warning: Failed to write Excel file '{excel_path}': {e}", file=sys.stderr
-        )
+        print(f"Warning: Failed to write Excel file '{excel_path}': {e}", file=sys.stderr)
 
 
 def compute_summary_rows(df, run_time_secs):
@@ -804,11 +778,7 @@ def compute_summary_rows(df, run_time_secs):
             op_time = run_time_secs
 
         # Concurrency: distinct thread IDs for this op category (issue #16)
-        n_threads = (
-            int(category_df.select(pl.col("thread").n_unique()).item())
-            if has_thread
-            else 0
-        )
+        n_threads = int(category_df.select(pl.col("thread").n_unique()).item()) if has_thread else 0
 
         # Compute statistically valid percentiles on ALL raw data for this category
         stats = category_df.select(
@@ -821,9 +791,7 @@ def compute_summary_rows(df, run_time_secs):
                 (pl.col("duration_ns").max() / 1000).alias("max_lat_us"),
                 (pl.col("bytes").mean() / 1024).alias("avg_obj_KB"),
                 (pl.count("op").cast(pl.Float64) / op_time).alias("ops_/_sec"),
-                (
-                    (pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / op_time
-                ).alias("xput_MBps"),
+                ((pl.col("bytes").sum().cast(pl.Float64) / (1024 * 1024)) / op_time).alias("xput_MBps"),
                 pl.count("op").alias("count"),
             ]
         )
@@ -889,20 +857,12 @@ def print_usage():
     print("  --skip=<time>  Skip specified time from start of each file")
     print("                 Format: <number>s (seconds) or <number>m (minutes)")
     print("                 Example: --skip=90s or --skip=5m")
-    print(
-        "  --per-client   Generate per-client statistics (in addition to overall stats)"
-    )
-    print(
-        "  --per-endpoint Generate per-endpoint statistics (in addition to overall stats)"
-    )
-    print(
-        "  --excel[=FILE] Export results to Excel file (default name derived from input file)"
-    )
+    print("  --per-client   Generate per-client statistics (in addition to overall stats)")
+    print("  --per-endpoint Generate per-endpoint statistics (in addition to overall stats)")
+    print("  --excel[=FILE] Export results to Excel file (default name derived from input file)")
     print("  --help         Show this help message and exit")
     print("\nArguments:")
-    print(
-        "  file1 file2... One or more oplog files to process (TSV/CSV, optionally .zst compressed)"
-    )
+    print("  file1 file2... One or more oplog files to process (TSV/CSV, optionally .zst compressed)")
 
 
 def print_error(message):
@@ -1013,13 +973,7 @@ def _excel_derive_path(paths):
     if len(paths) == 1:
         name = os.path.basename(paths[0])
         name = name.removesuffix(".zst")
-        name = (
-            name.removesuffix(".csv")
-            if name.endswith(".csv")
-            else name.removesuffix(".tsv")
-            if name.endswith(".tsv")
-            else name
-        )
+        name = name.removesuffix(".csv") if name.endswith(".csv") else name.removesuffix(".tsv") if name.endswith(".tsv") else name
         return os.path.join(os.path.dirname(paths[0]) or ".", name + ".xlsx")
     return "polarwarp-results.xlsx"
 
@@ -1057,15 +1011,10 @@ if __name__ == "__main__":
             else:
                 excel_m = excel_pattern.match(arg)
                 if excel_m:
-                    excel_path = excel_m.group(
-                        1
-                    )  # may be None if --excel with no value
+                    excel_path = excel_m.group(1)  # may be None if --excel with no value
                     if excel_path is None:
                         excel_path = ""  # sentinel: derive name later
-                    print(
-                        "Excel export enabled"
-                        + (f": {excel_path}" if excel_path else "")
-                    )
+                    print("Excel export enabled" + (f": {excel_path}" if excel_path else ""))
                     continue
                 match = skip_pattern.match(arg)
                 if match:
@@ -1155,9 +1104,7 @@ if __name__ == "__main__":
                 ]
                 missing_s = [c for c in required_summary if c not in summary_df.columns]
                 if missing_s:
-                    print_error(
-                        f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}"
-                    )
+                    print_error(f"Summary file '{file_path}' is missing required columns: {', '.join(missing_s)}")
                 summary_df = summary_df.with_columns(
                     [
                         pl.col("bps").cast(pl.Float64),
@@ -1180,9 +1127,7 @@ if __name__ == "__main__":
             # Try to read the file with error handling
             # glob=False prevents polars from treating brackets in filenames as glob patterns
             try:
-                df = pl.read_csv(
-                    file_path, ignore_errors=True, separator="\t", glob=False
-                )
+                df = pl.read_csv(file_path, ignore_errors=True, separator="\t", glob=False)
             except Exception as e:
                 print_error(f"Failed to read file '{file_path}': {e}")
 
@@ -1194,9 +1139,7 @@ if __name__ == "__main__":
             required_columns = ["start", "end", "op", "bytes", "duration_ns"]
             missing_columns = [col for col in required_columns if col not in df.columns]
             if missing_columns:
-                print_error(
-                    f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}"
-                )
+                print_error(f"File '{file_path}' is missing required columns: {', '.join(missing_columns)}")
 
             # Note: parsing the ISO 8601 time is a bit tricky.  If the value ends in a literal capital "Z", then it may cause problems.
             try:
@@ -1204,15 +1147,11 @@ if __name__ == "__main__":
                     [
                         pl.col("start")
                         .str.replace("Z$", "+00:00")
-                        .str.strptime(
-                            pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False
-                        )
+                        .str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False)
                         .alias("start"),
                         pl.col("end")
                         .str.replace("Z$", "+00:00")
-                        .str.strptime(
-                            pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False
-                        )
+                        .str.strptime(pl.Datetime, "%Y-%m-%dT%H:%M:%S%.f%z", strict=False)
                         .alias("end"),
                     ]
                 )
@@ -1237,9 +1176,7 @@ if __name__ == "__main__":
 
             # If this error is raised, likely a time parsing issue
             if start_time is None or end_time is None:
-                print_error(
-                    f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)"
-                )
+                print_error(f"Could not determine start/end time in file '{file_path}'. Check timestamp format (ISO 8601 expected)")
 
         except KeyboardInterrupt:
             print("\n\nInterrupted by user", file=sys.stderr)
@@ -1258,9 +1195,7 @@ if __name__ == "__main__":
             print(f"Skipping rows with 'start' <= {threshold_time}.")
             df = df.filter(pl.col("start") > threshold_time)
 
-        print(
-            f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}"
-        )
+        print(f"The file run time in h:mm:ss is {run_time}, time in seconds is: {run_time_secs}")
 
         # Define the bucket order (matching sai3-bench/polarwarp-rs)
         bucket_order = [
@@ -1376,14 +1311,8 @@ if __name__ == "__main__":
             )
             .with_columns(
                 [
-                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias(
-                        "ops_/_sec"
-                    ),
-                    (
-                        pl.col("bytes_sum").cast(pl.Float64)
-                        / (1024 * 1024)
-                        / pl.col("runtime_s")
-                    ).alias("xput_MBps"),
+                    (pl.col("count").cast(pl.Float64) / pl.col("runtime_s")).alias("ops_/_sec"),
+                    (pl.col("bytes_sum").cast(pl.Float64) / (1024 * 1024) / pl.col("runtime_s")).alias("xput_MBps"),
                 ]
             )
             .drop(["bytes_sum"])
@@ -1395,9 +1324,7 @@ if __name__ == "__main__":
         # Calculate throughput metrics for the current file (used in multi-file consolidation)
         throughput_metrics = df.group_by("op", "bytes_bucket").agg(
             [
-                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias(
-                    "xput_MBps"
-                ),
+                ((pl.col("bytes").sum() / (1024 * 1024)) / run_time_secs).alias("xput_MBps"),
                 pl.count("op").alias("count"),
             ]
         )
@@ -1428,9 +1355,7 @@ if __name__ == "__main__":
             "max_threads",
             "runtime_s",
         ]
-        final_result = final_result.select(
-            [c for c in _col_order if c in final_result.columns]
-        )
+        final_result = final_result.select([c for c in _col_order if c in final_result.columns])
 
         final_result_pd = final_result.to_pandas()
 
@@ -1449,13 +1374,9 @@ if __name__ == "__main__":
         ]
         for column in columns_to_format:
             if column in final_result_pd:
-                final_result_pd[column] = final_result_pd[column].map(
-                    format_with_commas
-                )
+                final_result_pd[column] = final_result_pd[column].map(format_with_commas)
         if "runtime_s" in final_result_pd:
-            final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(
-                lambda x: f"{x:.1f}"
-            )
+            final_result_pd["runtime_s"] = final_result_pd["runtime_s"].map(lambda x: f"{x:.1f}")
 
         print(final_result_pd.to_string(index=False))
 
@@ -1477,9 +1398,7 @@ if __name__ == "__main__":
 
         # Save data for Excel export
         if excel_path is not None:
-            saved_file_dfs.append(
-                {"path": file_path, "df": df, "run_secs": run_time_secs}
-            )
+            saved_file_dfs.append({"path": file_path, "df": df, "run_secs": run_time_secs})
 
         consolidated_df = pl.concat([consolidated_df, df])
 
@@ -1492,8 +1411,7 @@ if __name__ == "__main__":
     # Warn if user mixed trace and summary files
     if any_trace_file and any_summary_file:
         print(
-            "WARNING: Mixed trace and summary files provided.  "
-            "Consolidation is skipped for summary files; each is reported independently.",
+            "WARNING: Mixed trace and summary files provided.  Consolidation is skipped for summary files; each is reported independently.",
             file=sys.stderr,
         )
 
@@ -1535,22 +1453,13 @@ if __name__ == "__main__":
 
     overlap_secs = max(0.0, (overlap_end - overlap_start).total_seconds())
     union_secs = (union_end - union_start).total_seconds()
-    jaccard_pct = (
-        (overlap_secs / union_secs * 100.0)
-        if union_secs > 0 and overlap_secs > 0
-        else 0.0
-    )
+    jaccard_pct = (overlap_secs / union_secs * 100.0) if union_secs > 0 and overlap_secs > 0 else 0.0
 
-    print(
-        f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)"
-    )
+    print(f"  Overlap duration: {timedelta(seconds=overlap_secs)}  ({overlap_secs:.2f} s)")
     print(f"  Jaccard overlap: {jaccard_pct:.1f}%  (overlap / union)")
 
     if jaccard_pct < OVERLAP_MIN_PCT:
-        print(
-            f"WARNING: Files appear to be sequential runs "
-            f"({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold)."
-        )
+        print(f"WARNING: Files appear to be sequential runs ({jaccard_pct:.1f}% Jaccard overlap < {OVERLAP_MIN_PCT:.0f}% threshold).")
         print("  Skipping consolidation \u2013 per-file results above are still valid.")
         if excel_path is not None:
             write_polarwarp_excel(
@@ -1564,19 +1473,14 @@ if __name__ == "__main__":
 
     if jaccard_pct < OVERLAP_MAX_PCT:
         print(
-            f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  "
-            f"Filtering all files to overlap window before consolidating."
+            f"WARNING: Partial overlap detected ({jaccard_pct:.1f}% Jaccard).  Filtering all files to overlap window before consolidating."
         )
     else:
-        print(
-            f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window."
-        )
+        print(f"Files are concurrent runs ({jaccard_pct:.1f}% Jaccard).  Consolidating overlap window.")
 
     # Filter consolidated_df to only operations whose start falls within the overlap window.
     # This ensures counts and throughput are computed over the same time slice across all files.
-    consolidated_df = consolidated_df.filter(
-        (pl.col("start") >= overlap_start) & (pl.col("start") < overlap_end)
-    )
+    consolidated_df = consolidated_df.filter((pl.col("start") >= overlap_start) & (pl.col("start") < overlap_end))
 
     if consolidated_df.is_empty():
         print("No valid data in overlap window to consolidate.")
@@ -1584,18 +1488,14 @@ if __name__ == "__main__":
 
     consolidated_run_time = overlap_end - overlap_start
     consolidated_run_secs = overlap_secs
-    print(
-        f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}"
-    )
+    print(f"The consolidated running time in h:mm:ss is {consolidated_run_time}, time in seconds is: {consolidated_run_secs:.2f}")
 
     # Adjust consolidated_stats to join on both "op" and "bytes_bucket"
     if consolidated_df.is_empty():
         print("No valid data to consolidate.")
         sys.exit(1)
 
-    consolidated_stats = consolidated_df.group_by(
-        ["op", "bytes_bucket", "bucket_#"]
-    ).agg(
+    consolidated_stats = consolidated_df.group_by(["op", "bytes_bucket", "bucket_#"]).agg(
         [
             (pl.col("duration_ns").mean() / 1000).alias("mean_lat_us"),
             (pl.col("duration_ns").median() / 1000).alias("med._lat_us"),
@@ -1615,21 +1515,15 @@ if __name__ == "__main__":
             .agg(
                 [
                     pl.col("xput_MBps").sum().alias("total_xput_MBps"),
-                    (pl.col("count").sum() / consolidated_run_secs).alias(
-                        "tot_ops_/_sec"
-                    ),
+                    (pl.col("count").sum() / consolidated_run_secs).alias("tot_ops_/_sec"),
                 ]
             )
         )
     else:
-        combined_throughputs = pl.DataFrame(
-            {"op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []}
-        )
+        combined_throughputs = pl.DataFrame({"op": [], "bytes_bucket": [], "total_xput_MBps": [], "tot_ops_/_sec": []})
 
     # Join consolidated throughput metrics on "op" and "bytes_bucket"
-    consolidated_stats = consolidated_stats.join(
-        combined_throughputs, on=["op", "bytes_bucket"], how="left"
-    )
+    consolidated_stats = consolidated_stats.join(combined_throughputs, on=["op", "bytes_bucket"], how="left")
     consolidated_stats = consolidated_stats.sort(["bucket_#", "op"])
 
     # Ensure all expected columns are present and in the desired order
@@ -1648,9 +1542,7 @@ if __name__ == "__main__":
         "tot_count",
     ]
 
-    consolidated_stats = consolidated_stats.select(desired_column_order).sort(
-        ["bucket_#", "op"]
-    )
+    consolidated_stats = consolidated_stats.select(desired_column_order).sort(["bucket_#", "op"])
 
     # Convert to pandas for final output formatting
     consolidated_stats_pd = consolidated_stats.to_pandas()
@@ -1668,9 +1560,7 @@ if __name__ == "__main__":
     ]
     for column in columns_to_format:
         if column in consolidated_stats_pd:
-            consolidated_stats_pd[column] = consolidated_stats_pd[column].map(
-                format_with_commas
-            )
+            consolidated_stats_pd[column] = consolidated_stats_pd[column].map(format_with_commas)
 
     print("Consolidated Results:")
     print(consolidated_stats_pd)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "polarwarp"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Python implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -233,7 +233,7 @@ wheels = [
 
 [[package]]
 name = "polarwarp"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "pandas" },

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polarwarp-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Russ Fellows <russ.fellows@gmail.com>"]
 description = "A Rust implementation of polarWarp for processing warp output and s3dlio / sai3-bench oplog files"

--- a/rust/MANUAL.md
+++ b/rust/MANUAL.md
@@ -119,31 +119,44 @@ PolarWarp-rs outputs a table with the following columns:
 
 ## Excel Export
 
-Use `--excel` to export results to an Excel `.xlsx` workbook:
+Use `--excel` to export results to an Excel `.xlsx` workbook. There are three usage modes depending on which file(s) you pass:
 
 ```bash
-# Export to auto-named file (derived from first input filename)
-polarwarp-rs --excel oplog.tsv.zst
+# Mode 1 — Trace file only
+# Produces: Results + Detail tabs (latency percentiles, throughput, op counts)
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst
 
-# Export to a specific file
-polarwarp-rs --excel=report.xlsx agent-1.tsv.zst agent-2.tsv.zst
+# Mode 2 — Summary file only
+# Produces: Summary tab (raw per-second rows) + Charts tab (XY scatter plots)
+polarwarp-rs --excel=report.xlsx run.summary.tsv.zst
+
+# Mode 3 — Both files together (recommended for a complete picture)
+# Produces: all four tabs in one workbook
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst run.summary.tsv.zst
+
+# The trace and summary files from the same warp run share a base filename:
+#   warp-mixed-2026-05-15[153937]-Gn1h.trace.tsv.zst
+#   warp-mixed-2026-05-15[153937]-Gn1h.summary.tsv.zst
+
+# Export to auto-named file (derived from first input filename)
+polarwarp-rs --excel run.trace.tsv.zst
 
 # Combine with other options
-polarwarp-rs --skip 90s --per-endpoint --excel=report.xlsx oplog.tsv.zst
+polarwarp-rs --skip 90s --per-endpoint --excel=report.xlsx run.trace.tsv.zst run.summary.tsv.zst
 ```
 
 ### Workbook Structure
 
-Each workbook contains the following sheets:
+Sheets produced depend on the input file type(s):
 
-| Sheet | Contents |
-|-------|----------|
-| `<filename>-Results` | Full size-bucketed statistics table for one trace file |
-| `<filename>-Detail` | Per-endpoint (or per-client) breakdown for one trace file |
-| `Consolidated-Results` | Merged results across all trace files (only present when `>1` file is given) |
-| `Consolidated-Detail` | Merged per-endpoint breakdown (only when `>1` trace file is given) |
-| `<filename>-Summary` | Aggregate throughput statistics per op type for one summary file |
-| `<filename>-Charts` | Per-second time-series data with ops/sec and MiB/s line charts for one summary file |
+| Sheet | Source | Contents |
+|-------|--------|----------|
+| `<filename>-Results` | Trace | Full size-bucketed statistics table (latency, throughput, op counts) |
+| `<filename>-Detail` | Trace | Per-endpoint or per-client breakdown |
+| `Consolidated-Results` | Trace (multiple) | Merged results across all trace files |
+| `Consolidated-Detail` | Trace (multiple) | Merged per-endpoint breakdown |
+| `<filename>-Summary` | Summary | Raw per-second rows: op, start, end, GBps, ops/sec, errors |
+| `<filename>-Charts` | Summary | Two XY scatter charts: Throughput (GB/s) and I/O Rate (ops/sec) over elapsed time, one series per op type (GET, PUT, etc.; TOTAL excluded) |
 
 Detail tabs contain three sections:
 - **Overall** — aggregate per-endpoint stats (all op types combined)

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,6 +1,6 @@
 # PolarWarp - Rust Implementation
 
-[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](Cargo.toml)
+[![Version](https://img.shields.io/badge/version-0.2.1-blue.svg)](Cargo.toml)
 [![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE)
 [![Tests](https://img.shields.io/badge/tests-28%20passing-brightgreen.svg)](src/main.rs)
@@ -60,11 +60,14 @@ polarwarp-rs --skip 2m oplog.trace.tsv.zst
 # Compare performance across multiple clients
 polarwarp-rs --per-client multi_client_oplog.trace.tsv.zst
 
-# Export results to Excel
-polarwarp-rs --excel report.xlsx oplog.trace.tsv.zst
+# Trace file only → Results + Detail tabs (latency percentiles, throughput, op counts)
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst
 
-# Summary files produce a Stats tab + a Charts tab (ops/sec and MiB/s over time)
-polarwarp-rs --excel run.summary.tsv.zst
+# Summary file only → Summary tab (raw per-second rows) + Charts tab (XY scatter)
+polarwarp-rs --excel=report.xlsx run.summary.tsv.zst
+
+# Both files together → all four tabs in one workbook (recommended)
+polarwarp-rs --excel=report.xlsx run.trace.tsv.zst run.summary.tsv.zst
 
 # Per-endpoint breakdown
 polarwarp-rs --per-endpoint oplog.trace.tsv.zst

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -2196,8 +2196,7 @@ fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &s
         series_info.push((op.clone(), t_col, g_col, o_col, data.len() as u32));
     }
 
-    let max_rows = series_info.iter().map(|s| s.4).max().unwrap_or(0);
-    let chart_row = max_rows + 3;
+    let data_cols = (op_names.len() * 3) as u16;
 
     let mut marker = ChartMarker::new();
     marker.set_size(4);
@@ -2219,7 +2218,7 @@ fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &s
             .set_values((tab_name, 1, *g_col, *n_rows, *g_col))
             .set_marker(&marker);
     }
-    ws.insert_chart(chart_row, 0, &chart_bw)?;
+    ws.insert_chart(1, data_cols + 1, &chart_bw)?;
 
     let ops_chart_title = format!("I/O Rate ({}) over Time", ops_unit);
     let ops_y_label = ops_unit.to_string();
@@ -2238,7 +2237,7 @@ fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &s
             .set_values((tab_name, 1, *o_col, *n_rows, *o_col))
             .set_marker(&marker);
     }
-    ws.insert_chart(chart_row, 8, &chart_ops)?;
+    ws.insert_chart(1, data_cols + 9, &chart_ops)?;
 
     Ok(())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -11,7 +11,7 @@ use clap::{ArgAction, Parser};
 use num_format::{Locale, ToFormattedString};
 use polars::prelude::*;
 use regex::Regex;
-use rust_xlsxwriter::{Chart, ChartLegendPosition, ChartType, Format, Workbook};
+use rust_xlsxwriter::{Chart, ChartLegendPosition, ChartMarker, ChartType, Format, Workbook};
 
 /// Rows for one Excel results tab and one detail tab: (results_rows, detail_rows)
 type ExcelTabRows = (Vec<Vec<String>>, Vec<Vec<String>>);
@@ -1907,94 +1907,72 @@ fn compute_and_display_summary_stats(df: &DataFrame) -> Result<()> {
     Ok(())
 }
 
-/// Collect summary stats rows for Excel export (header + data rows, no commas in numbers).
+/// Convert nanoseconds since Unix epoch to a UTC timestamp string (YYYY-MM-DDTHH:MM:SSZ).
+/// Uses the civil_from_days algorithm (Howard Hinnant) — no external crates required.
+fn ns_to_rfc3339(ns: i64) -> String {
+    let s = (ns.max(0) / 1_000_000_000) as u64;
+    let h = (s % 86400) / 3600;
+    let min = (s % 3600) / 60;
+    let sec = s % 60;
+    let days = s / 86400;
+    // civil_from_days: http://howardhinnant.github.io/date_algorithms.html
+    let z = days as i64 + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y, mo, d, h, min, sec
+    )
+}
+
+/// Collect raw per-second summary rows for Excel export.
+/// Returns every row from the file (header + data), sorted chronologically.
+/// Columns: op | start | end | GBps | ops_per_sec | errors
 fn collect_summary_excel_rows(df: &DataFrame) -> Result<Vec<Vec<String>>> {
-    let stats = df
+    let df_sorted = df
         .clone()
         .lazy()
-        .group_by([col("op")])
-        .agg([
-            col("bps").count().alias("segments"),
-            (col("bps").mean() / lit(1_048_576.0)).alias("mean_MBps"),
-            (col("bps").median() / lit(1_048_576.0)).alias("p50_MBps"),
-            (col("bps").quantile(lit(0.90), QuantileMethod::Linear) / lit(1_048_576.0))
-                .alias("p90_MBps"),
-            (col("bps").quantile(lit(0.99), QuantileMethod::Linear) / lit(1_048_576.0))
-                .alias("p99_MBps"),
-            (col("bps").min() / lit(1_048_576.0)).alias("min_MBps"),
-            (col("bps").max() / lit(1_048_576.0)).alias("max_MBps"),
-            (col("bps").std(1) / lit(1_048_576.0)).alias("stdev_MBps"),
-            col("ops_per_sec").mean().alias("mean_ops"),
-            col("ops_per_sec").median().alias("p50_ops"),
-            col("ops_per_sec")
-                .quantile(lit(0.99), QuantileMethod::Linear)
-                .alias("p99_ops"),
-            col("errors")
-                .cast(DataType::Int64)
-                .sum()
-                .alias("total_errors"),
-        ])
-        .sort(["op"], SortMultipleOptions::default())
+        .sort(["start_ns", "op"], SortMultipleOptions::default())
         .collect()?;
 
     let mut rows: Vec<Vec<String>> = vec![vec![
         "op".into(),
-        "segments".into(),
-        "mean_MBps".into(),
-        "p50_MBps".into(),
-        "p90_MBps".into(),
-        "p99_MBps".into(),
-        "min_MBps".into(),
-        "max_MBps".into(),
-        "stdev_MBps".into(),
-        "mean_ops/s".into(),
-        "p50_ops/s".into(),
-        "p99_ops/s".into(),
-        "total_errors".into(),
+        "start".into(),
+        "end".into(),
+        "GBps".into(),
+        "ops_per_sec".into(),
+        "errors".into(),
     ]];
 
-    let op_col = stats.column("op")?.str()?;
-    let segs_col = stats.column("segments")?.u32()?;
-    let mean_col = stats.column("mean_MBps")?.f64()?;
-    let p50_col = stats.column("p50_MBps")?.f64()?;
-    let p90_col = stats.column("p90_MBps")?.f64()?;
-    let p99_col = stats.column("p99_MBps")?.f64()?;
-    let min_col = stats.column("min_MBps")?.f64()?;
-    let max_col = stats.column("max_MBps")?.f64()?;
-    let stdev_col = stats.column("stdev_MBps")?.f64()?;
-    let mops_col = stats.column("mean_ops")?.f64()?;
-    let p50ops_col = stats.column("p50_ops")?.f64()?;
-    let p99ops_col = stats.column("p99_ops")?.f64()?;
-    let errs_col = stats.column("total_errors")?.i64()?;
+    let op_col = df_sorted.column("op")?.str()?;
+    let start_col = df_sorted.column("start_ns")?.i64()?;
+    let end_col = df_sorted.column("end_ns")?.i64()?;
+    let bps_col = df_sorted.column("bps")?.f64()?;
+    let ops_col = df_sorted.column("ops_per_sec")?.f64()?;
+    let errs_col = df_sorted.column("errors")?.i64()?;
 
-    // Non-TOTAL rows first, then TOTAL
-    let height = stats.height();
-    let push_row = |rows: &mut Vec<Vec<String>>, i: usize| {
+    for i in 0..df_sorted.height() {
+        let op = op_col.get(i).unwrap_or("").to_string();
+        let start_ns = start_col.get(i).unwrap_or(0);
+        let end_ns = end_col.get(i).unwrap_or(0);
+        let bps = bps_col.get(i).unwrap_or(0.0);
+        let ops = ops_col.get(i).unwrap_or(0.0);
+        let errors = errs_col.get(i).unwrap_or(0);
         rows.push(vec![
-            op_col.get(i).unwrap_or("?").to_string(),
-            segs_col.get(i).unwrap_or(0).to_string(),
-            format!("{:.2}", mean_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", p50_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", p90_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", p99_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", min_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", max_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", stdev_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", mops_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", p50ops_col.get(i).unwrap_or(0.0)),
-            format!("{:.2}", p99ops_col.get(i).unwrap_or(0.0)),
-            errs_col.get(i).unwrap_or(0).to_string(),
+            op,
+            ns_to_rfc3339(start_ns),
+            ns_to_rfc3339(end_ns),
+            format!("{:.3}", bps / 1_000_000_000.0),
+            format!("{:.3}", ops),
+            errors.to_string(),
         ]);
-    };
-    for i in 0..height {
-        if op_col.get(i).unwrap_or("") != "TOTAL" {
-            push_row(&mut rows, i);
-        }
-    }
-    for i in 0..height {
-        if op_col.get(i).unwrap_or("") == "TOTAL" {
-            push_row(&mut rows, i);
-        }
     }
 
     Ok(rows)
@@ -2126,63 +2104,66 @@ fn write_excel_workbook_with_chart_tabs(
     Ok(())
 }
 
-/// Write a worksheet with per-second time-series data and two embedded line charts:
-///   1. Operations/sec over Time (one series per non-TOTAL op)
-///   2. Throughput MiB/s over Time (GET and PUT only — META has no byte payload)
-///
-/// Column layout: [seconds | <op>_ops … | <op>_MBps …]
-/// Charts are inserted below the data table, side by side.
+/// Write a worksheet with raw time-series data and two embedded XY scatter charts.
+/// TOTAL rows are excluded; only per-op rows (GET, PUT, …) are plotted.
+/// Column layout: [{op}_time_s | {op}_GBps | {op}_ops_s] repeated for each op.
+/// Chart 1 (left):  Throughput (GB/s) vs Elapsed Time — one series per op.
+/// Chart 2 (right): I/O Rate (ops/sec) vs Elapsed Time — one series per op.
 fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &str) -> Result<()> {
-    // Filter TOTAL rows; sort by time then op for deterministic ordering
-    let df_filt = df
+    // Compute global min_ns from the full dataset (consistent X axis origin)
+    let min_ns = df.column("start_ns")?.i64()?.min().unwrap_or(0);
+
+    // Exclude TOTAL and zero-throughput rows (warmup/cooldown)
+    let df_chart = df
         .clone()
         .lazy()
-        .filter(col("op").neq(lit("TOTAL")))
-        .sort(["start_ns", "op"], SortMultipleOptions::default())
+        .filter(col("op").neq(lit("TOTAL")).and(col("bps").gt(lit(0.0))))
+        .sort(["op", "start_ns"], SortMultipleOptions::default())
         .collect()?;
 
-    if df_filt.height() == 0 {
+    if df_chart.height() == 0 {
         return Ok(());
     }
 
-    let op_col = df_filt.column("op")?.str()?;
-    let start_col = df_filt.column("start_ns")?.i64()?;
-    let bps_col = df_filt.column("bps")?.f64()?;
-    let ops_col = df_filt.column("ops_per_sec")?.f64()?;
+    // Auto-scale throughput unit based on peak bps in this dataset
+    let max_bps = df_chart.column("bps")?.f64()?.max().unwrap_or(0.0);
+    let (bw_divisor, bw_unit, bw_col_suffix) = if max_bps >= 1_000_000_000.0 {
+        (1_000_000_000.0_f64, "GB/s", "GBps")
+    } else {
+        (1_000_000.0_f64, "MB/s", "MBps")
+    };
 
-    let min_ns = start_col.min().unwrap_or(0);
+    // Auto-scale ops unit based on peak ops/sec in this dataset
+    let max_ops = df_chart.column("ops_per_sec")?.f64()?.max().unwrap_or(0.0);
+    let (ops_divisor, ops_unit, ops_col_suffix) = if max_ops >= 1_000.0 {
+        (1_000.0_f64, "Kops/s", "Kops_s")
+    } else {
+        (1.0_f64, "ops/s", "ops_s")
+    };
 
-    // Collect unique ops (sorted) and unique second offsets (sorted)
-    let mut ops_set: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut secs_set: std::collections::HashSet<i64> = std::collections::HashSet::new();
-    for i in 0..df_filt.height() {
-        ops_set.insert(op_col.get(i).unwrap_or("").to_string());
-        secs_set.insert((start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000);
-    }
-    let mut all_ops: Vec<String> = ops_set.into_iter().collect();
-    all_ops.sort();
-    let mut all_secs: Vec<i64> = secs_set.into_iter().collect();
-    all_secs.sort();
+    let op_col = df_chart.column("op")?.str()?;
+    let start_col = df_chart.column("start_ns")?.i64()?;
+    let bps_col = df_chart.column("bps")?.f64()?;
+    let ops_col = df_chart.column("ops_per_sec")?.f64()?;
 
-    let n_rows = all_secs.len();
-    let n_ops = all_ops.len();
-
-    // Build per-(op, seconds) lookup → (ops_per_sec, MBps)
-    let mut lookup: std::collections::HashMap<(String, i64), (f64, f64)> =
+    // Collect per-op data: op → Vec<(elapsed_s, GBps, ops_s)>
+    let mut op_names: Vec<String> = Vec::new();
+    let mut op_data: std::collections::HashMap<String, Vec<(f64, f64, f64)>> =
         std::collections::HashMap::new();
-    for i in 0..df_filt.height() {
+    for i in 0..df_chart.height() {
         let op = op_col.get(i).unwrap_or("").to_string();
-        let secs = (start_col.get(i).unwrap_or(0) - min_ns) / 1_000_000_000;
-        let ops = ops_col.get(i).unwrap_or(0.0);
-        let mbps = bps_col.get(i).unwrap_or(0.0) / 1_048_576.0;
-        lookup.insert((op, secs), (ops, mbps));
+        let elapsed_s = (start_col.get(i).unwrap_or(0) - min_ns) as f64 / 1_000_000_000.0;
+        let bw = bps_col.get(i).unwrap_or(0.0) / bw_divisor;
+        let ops = ops_col.get(i).unwrap_or(0.0) / ops_divisor;
+        op_data
+            .entry(op.clone())
+            .or_default()
+            .push((elapsed_s, bw, ops));
+        if !op_names.contains(&op) {
+            op_names.push(op);
+        }
     }
-
-    // ops for throughput chart: GET and PUT only (META has no byte payload)
-    let bw_ops: Vec<&String> = all_ops
-        .iter()
-        .filter(|o| o.as_str() == "GET" || o.as_str() == "PUT")
-        .collect();
+    op_names.sort(); // alphabetical (TOTAL already excluded)
 
     // ── Write worksheet ───────────────────────────────────────────────────────
     let ws = workbook.add_worksheet();
@@ -2191,82 +2172,73 @@ fn write_summary_chart_tab(workbook: &mut Workbook, df: &DataFrame, tab_name: &s
     let header_fmt = Format::new().set_bold().set_font_name("Aptos");
     let data_fmt = Format::new().set_font_name("Aptos");
 
-    // Header row: seconds | <op>_ops … | <op>_MBps …
-    ws.write_string_with_format(0, 0, "seconds", &header_fmt)?;
-    for (oi, op) in all_ops.iter().enumerate() {
-        ws.write_string_with_format(0, (oi + 1) as u16, format!("{}_ops", op), &header_fmt)?;
-    }
-    for (bi, op) in bw_ops.iter().enumerate() {
-        ws.write_string_with_format(
-            0,
-            (n_ops + 1 + bi) as u16,
-            format!("{}_MBps", op),
-            &header_fmt,
-        )?;
-    }
+    // (op, t_col, gbps_col, ops_col, n_rows)
+    let mut series_info: Vec<(String, u16, u16, u16, u32)> = Vec::new();
 
-    // Data rows
-    for (ri, &secs) in all_secs.iter().enumerate() {
-        let row = (ri + 1) as u32;
-        ws.write_number_with_format(row, 0, secs as f64, &data_fmt)?;
-        for (oi, op) in all_ops.iter().enumerate() {
-            if let Some(&(ops, _)) = lookup.get(&(op.clone(), secs)) {
-                ws.write_number_with_format(row, (oi + 1) as u16, ops, &data_fmt)?;
-            }
+    for (oi, op) in op_names.iter().enumerate() {
+        let t_col = (oi * 3) as u16;
+        let g_col = t_col + 1;
+        let o_col = t_col + 2;
+        ws.write_string_with_format(0, t_col, format!("{}_time_s", op), &header_fmt)?;
+        ws.write_string_with_format(0, g_col, format!("{}_{}", op, bw_col_suffix), &header_fmt)?;
+        ws.write_string_with_format(0, o_col, format!("{}_{}", op, ops_col_suffix), &header_fmt)?;
+
+        let data = op_data.get(op).map(|v| v.as_slice()).unwrap_or(&[]);
+        for (ri, &(t, g, o)) in data.iter().enumerate() {
+            let row = (ri + 1) as u32;
+            ws.write_number_with_format(row, t_col, t, &data_fmt)?;
+            ws.write_number_with_format(row, g_col, g, &data_fmt)?;
+            ws.write_number_with_format(row, o_col, o, &data_fmt)?;
         }
-        for (bi, op) in bw_ops.iter().enumerate() {
-            if let Some(&(_, mbps)) = lookup.get(&((*op).clone(), secs)) {
-                ws.write_number_with_format(row, (n_ops + 1 + bi) as u16, mbps, &data_fmt)?;
-            }
-        }
+        ws.set_column_width(t_col, 12.0)?;
+        ws.set_column_width(g_col, 12.0)?;
+        ws.set_column_width(o_col, 12.0)?;
+        series_info.push((op.clone(), t_col, g_col, o_col, data.len() as u32));
     }
 
-    // Set column widths
-    let n_cols = 1 + n_ops + bw_ops.len();
-    for ci in 0..n_cols {
-        ws.set_column_width(ci as u16, 13.0)?;
+    let max_rows = series_info.iter().map(|s| s.4).max().unwrap_or(0);
+    let chart_row = max_rows + 3;
+
+    let mut marker = ChartMarker::new();
+    marker.set_size(4);
+
+    let bw_chart_title = format!("Throughput ({}) over Time", bw_unit);
+    let bw_y_label = format!("Throughput ({})", bw_unit);
+
+    // ── Chart 1: Throughput (…) ───────────────────────────────────────────────
+    let mut chart_bw = Chart::new(ChartType::ScatterStraightWithMarkers);
+    chart_bw.title().set_name(&bw_chart_title);
+    chart_bw.x_axis().set_name("Elapsed Time (s)");
+    chart_bw.y_axis().set_name(&bw_y_label);
+    chart_bw.legend().set_position(ChartLegendPosition::Bottom);
+    for (op, t_col, g_col, _, n_rows) in &series_info {
+        chart_bw
+            .add_series()
+            .set_name(op.as_str())
+            .set_categories((tab_name, 1, *t_col, *n_rows, *t_col))
+            .set_values((tab_name, 1, *g_col, *n_rows, *g_col))
+            .set_marker(&marker);
     }
+    ws.insert_chart(chart_row, 0, &chart_bw)?;
 
-    // ── Charts ────────────────────────────────────────────────────────────────
-    let chart_row = (n_rows + 3) as u32;
+    let ops_chart_title = format!("I/O Rate ({}) over Time", ops_unit);
+    let ops_y_label = ops_unit.to_string();
 
-    // Chart 1: ops/sec over time
-    if n_ops > 0 {
-        let mut chart_ops = Chart::new(ChartType::Line);
-        chart_ops.title().set_name("Operations/sec over Time");
-        chart_ops.x_axis().set_name("Seconds");
-        chart_ops.y_axis().set_name("ops/sec");
-        chart_ops.legend().set_position(ChartLegendPosition::Bottom);
-
-        for (oi, op) in all_ops.iter().enumerate() {
-            let data_col = (oi + 1) as u16;
-            chart_ops
-                .add_series()
-                .set_name(op.as_str())
-                .set_categories((tab_name, 1, 0, n_rows as u32, 0))
-                .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
-        }
-        ws.insert_chart(chart_row, 0, &chart_ops)?;
+    // ── Chart 2: I/O Rate (…) ───────────────────────────────────────────
+    let mut chart_ops = Chart::new(ChartType::ScatterStraightWithMarkers);
+    chart_ops.title().set_name(&ops_chart_title);
+    chart_ops.x_axis().set_name("Elapsed Time (s)");
+    chart_ops.y_axis().set_name(&ops_y_label);
+    chart_ops.legend().set_position(ChartLegendPosition::Bottom);
+    for (op, t_col, _, o_col, n_rows) in &series_info {
+        chart_ops
+            .add_series()
+            .set_name(op.as_str())
+            .set_categories((tab_name, 1, *t_col, *n_rows, *t_col))
+            .set_values((tab_name, 1, *o_col, *n_rows, *o_col))
+            .set_marker(&marker);
     }
-
-    // Chart 2: throughput (MiB/s) — GET and PUT only
-    if !bw_ops.is_empty() {
-        let mut chart_bw = Chart::new(ChartType::Line);
-        chart_bw.title().set_name("Throughput (MiB/s) over Time");
-        chart_bw.x_axis().set_name("Seconds");
-        chart_bw.y_axis().set_name("MiB/s");
-        chart_bw.legend().set_position(ChartLegendPosition::Bottom);
-
-        for (bi, op) in bw_ops.iter().enumerate() {
-            let data_col = (n_ops + 1 + bi) as u16;
-            chart_bw
-                .add_series()
-                .set_name(op.as_str())
-                .set_categories((tab_name, 1, 0, n_rows as u32, 0))
-                .set_values((tab_name, 1, data_col, n_rows as u32, data_col));
-        }
-        ws.insert_chart(chart_row, 8, &chart_bw)?;
-    }
+    ws.insert_chart(chart_row, 8, &chart_ops)?;
 
     Ok(())
 }


### PR DESCRIPTION
# PR: XY scatter charts, auto-scaling units, plain summary TSV support — v0.2.1

**Branch:** `feat/excel-scatter-autoscale` → `main`
**Repo:** russfellows/polarWarp

---

## Summary

Two commits adding XY scatter charts with auto-scaling throughput units,
plain (uncompressed) summary TSV support, and a chart positioning fix so
charts are immediately visible without scrolling.

---

## Commits

### 1. `f8753a7` — feat: XY scatter charts, auto-scaling units, plain summary TSV support — v0.2.1

**Charts (Rust + Python)**
- Replace line charts with XY scatter charts using time (seconds) as the
  X axis — values now align precisely on the time axis rather than by
  row index, which matters when rows are not uniformly spaced.
- Auto-scaling throughput units: display in MB/s when peak < 1 GB/s,
  GB/s otherwise. Y-axis label and chart title update accordingly.

**Plain summary TSV**
- Accept uncompressed `.summary.tsv` files in addition to the existing
  `.summary.tsv.zst` format. Warp v1.4.1-replay.4+ writes summary files
  uncompressed; this change makes polarWarp compatible with both old and
  new warp output.

**Version bump**
- Python: `pyproject.toml` → v0.2.1; `uv.lock` synced.
- Rust: `Cargo.toml` → v0.2.1.

**Documentation**
- `Changelog.md`: v0.2.1 entry.
- `README.md`, `rust/README.md`, `rust/MANUAL.md`: updated examples and
  output format descriptions.

---

### 2. `4f95934` — Move charts to right of data instead of below it

**Problem:** On the Charts tab, time-series charts were anchored below
the last data row (~177 rows down). Users had to scroll ~600 rows to see
them after opening the file.

**Fix (Python):**
```python
n_data_cols = len(ts_pd.columns)
ws.insert_chart(1, n_data_cols + 1, chart_bw)   # Throughput
ws.insert_chart(1, n_data_cols + 9, chart_ops)  # I/O Rate
```

**Fix (Rust):**
```rust
let data_cols = (op_names.len() * 3) as u16;  // 3 cols/op: time, GBps, ops_s
ws.insert_chart(1, data_cols + 1, &chart_bw)?;
ws.insert_chart(1, data_cols + 9, &chart_ops)?;
```

Charts are now placed at row 1, immediately to the right of the data
columns — visible as soon as the sheet opens.

---

## Files Changed

| File | Change |
|------|--------|
| `python/polarwarp.py` | XY scatter, auto-scale, plain TSV, chart position |
| `python/pyproject.toml` | v0.2.0 → v0.2.1 |
| `python/uv.lock` | synced to v0.2.1 |
| `rust/src/main.rs` | XY scatter, auto-scale, plain TSV, chart position |
| `rust/Cargo.toml` | v0.2.0 → v0.2.1 |
| `rust/MANUAL.md` | updated usage examples |
| `rust/README.md` | updated output format notes |
| `README.md` | updated top-level docs |
| `Changelog.md` | v0.2.1 entry |

9 files changed, 399 insertions(+), 466 deletions(-)